### PR TITLE
pvh: Support booting via PVH ELFNOTE

### DIFF
--- a/layout.ld
+++ b/layout.ld
@@ -3,6 +3,7 @@ ENTRY(linux64_start)
 PHDRS
 {
   ram  PT_LOAD FILEHDR PHDRS ;
+  note PT_NOTE               ;
 }
 
 /* Loaders like to put stuff in low memory (< 1M), so we don't use it. */
@@ -13,9 +14,10 @@ stack_size = 64K;
 
 SECTIONS
 {
-	/* Mapping the program headers into RAM makes the file smaller. */
+	/* Mapping the program headers and note into RAM makes the file smaller. */
 	. = ram_min;
 	. += SIZEOF_HEADERS;
+	.note : { *(.note) } :note :ram
 
 	/* These sections are mapped into RAM from the file. Omitting :ram from
 	   later sections avoids emitting empty sections in the final binary.     */

--- a/layout.ld
+++ b/layout.ld
@@ -1,4 +1,4 @@
-ENTRY(ram64_start)
+ENTRY(linux64_start)
 
 PHDRS
 {

--- a/layout.ld
+++ b/layout.ld
@@ -2,7 +2,7 @@ ENTRY(ram64_start)
 
 PHDRS
 {
-  program PT_LOAD FILEHDR PHDRS ;
+  ram  PT_LOAD FILEHDR PHDRS ;
 }
 
 /* Loaders like to put stuff in low memory (< 1M), so we don't use it. */
@@ -13,16 +13,26 @@ stack_size = 64K;
 
 SECTIONS
 {
-	/* Mapping in the program headers makes it easier to mmap the whole file. */
+	/* Mapping the program headers into RAM makes the file smaller. */
 	. = ram_min;
 	. += SIZEOF_HEADERS;
 
-	.rodata : { *(.rodata .rodata.*) } :program
-	.text   : { *(.text .text.*)     } :program
-	.data   : { *(.data .data.*)     } :program
-	.bss    : { *(.bss .bss.*)       } :program
+	/* These sections are mapped into RAM from the file. Omitting :ram from
+	   later sections avoids emitting empty sections in the final binary.     */
+	data_start = .;
+	.rodata : { *(.rodata .rodata.*) } :ram
+	.text   : { *(.text .text.*)     }
+	.data   : { *(.data .data.*)     }
+	data_size = . - data_start;
 
-	firmware_ram_size = . - ram_min;
+	/* The BSS section isn't mapped from any file data. It is simply zeroed
+	   in RAM. So our file size should be computed from here.                 */
+	file_size = . - ram_min;
+	.bss : {
+		bss_start = .;
+		*(.bss .bss.*)
+		bss_size = . - bss_start;
+	}
 
 	ASSERT((. <= ram_max - stack_size), "firmware size too big for RAM region")
 

--- a/layout.ld
+++ b/layout.ld
@@ -22,6 +22,7 @@ SECTIONS
 	data_start = .;
 	.rodata : { *(.rodata .rodata.*) } :ram
 	.text   : { *(.text .text.*)     }
+	.text32 : { *(.text32)           }
 	.data   : { *(.data .data.*)     }
 	data_size = . - data_start;
 

--- a/src/asm/gdt64.s
+++ b/src/asm/gdt64.s
@@ -1,0 +1,32 @@
+.section .rodata, "a"
+
+gdt64_ptr:
+    .short gdt64_end - gdt64_start - 1 # GDT length is actually (length - 1)
+    .quad gdt64_start
+
+gdt64_start: # First descriptor is always null
+    .quad 0
+code64_desc: # 64-bit Code-Segments always have: Base = 0, Limit = 4G
+    # CS.Limit[15:00] = 0                - Ignored
+    .short 0x0000
+    # CS.Base[15:00]  = 0                - Ignored
+    .short 0x0000
+    # CS.Base[23:16]  = 0   (bits 0-7)   - Ignored
+    .byte 0x00
+    # CS.Accessed     = 1   (bit  8)     - Don't write to segment on first use
+    # CS.ReadEnable   = 1   (bit  9)     - Read/Execute Code-Segment
+    # CS.Conforming   = 0   (bit  10)    - Nonconforming, no lower-priv access
+    # CS.Executable   = 1   (bit  11)    - Code-Segement
+    # CS.S            = 1   (bit  12)    - Not a System-Segement
+    # CS.DPL          = 0   (bits 13-14) - We only use this segment in Ring 0
+    # CS.P            = 1   (bit  15)    - Segment is present
+    .byte 0b10011011
+    # CS.Limit[19:16] = 0   (bits 16-19) - Ignored
+    # CS.AVL          = 0   (bit  20)    - Our software doesn't use this bit
+    # CS.L            = 1   (bit  21)    - This isn't a 64-bit segment
+    # CS.D            = 0   (bit  22)    - This is a 32-bit segment
+    # CS.G            = 0   (bit  23)    - Ignored
+    .byte 0b00100000
+    # CS.Base[31:24]  = 0   (bits 24-31) - Ignored
+    .byte 0x00
+gdt64_end:

--- a/src/asm/mod.rs
+++ b/src/asm/mod.rs
@@ -1,1 +1,3 @@
+global_asm!(include_str!("ram32.s"));
 global_asm!(include_str!("ram64.s"));
+global_asm!(include_str!("gdt64.s"));

--- a/src/asm/mod.rs
+++ b/src/asm/mod.rs
@@ -1,3 +1,4 @@
+global_asm!(include_str!("note.s"));
 global_asm!(include_str!("ram32.s"));
 global_asm!(include_str!("ram64.s"));
 global_asm!(include_str!("gdt64.s"));

--- a/src/asm/note.s
+++ b/src/asm/note.s
@@ -1,0 +1,20 @@
+.section .note, "a"
+
+# From xen/include/public/elfnote.h, "Physical entry point into the kernel."
+XEN_ELFNOTE_PHYS32_ENTRY = 18
+
+# We don't bother defining an ELFNOTE macro, as we only have one note.
+# This is equialent to the kernel's:
+# ELFNOTE(Xen, XEN_ELFNOTE_PHYS32_ENTRY, .long pvh_start)
+.align 4
+    .long name_end - name_start    # namesz
+    .long desc_end - desc_start    # descsz
+    .long XEN_ELFNOTE_PHYS32_ENTRY # type
+name_start:
+    .asciz "Xen"
+name_end:
+.align 4
+desc_start:
+    .long ram32_start
+desc_end:
+.align 4

--- a/src/asm/ram32.s
+++ b/src/asm/ram32.s
@@ -1,0 +1,46 @@
+.section .text32, "ax"
+.code32
+
+ram32_start:
+    # Stash the PVH start_info struct in %rdi.
+    movl %ebx, %edi
+    # Zero out %rsi, its value is unspecificed in the PVH Boot Protocol.
+    xorl %esi, %esi
+
+setup_page_tables:
+    # First L2 entry identity maps [0, 2 MiB)
+    movl $0b10000011, (L2_TABLES) # huge (bit 7), writable (bit 1), present (bit 0)
+    # First L3 entry points to L2 table
+    movl $L2_TABLES, %eax
+    orb  $0b00000011, %al # writable (bit 1), present (bit 0)
+    movl %eax, (L3_TABLE)
+    # First L4 entry points to L3 table
+    movl $L3_TABLE, %eax
+    orb  $0b00000011, %al # writable (bit 1), present (bit 0)
+    movl %eax, (L4_TABLE)
+
+enable_paging:
+    # Load page table root into CR3
+    movl $L4_TABLE, %eax
+    movl %eax, %cr3
+
+    # Set CR4.PAE (Physical Address Extension)
+    movl %cr4, %eax
+    orb  $0b00100000, %al # Set bit 5
+    movl %eax, %cr4
+    # Set EFER.LME (Long Mode Enable)
+    movl $0xC0000080, %ecx
+    rdmsr
+    orb  $0b00000001, %ah # Set bit 8
+    wrmsr
+    # Set CRO.PG (Paging)
+    movl %cr0, %eax
+    orl  $(1 << 31), %eax
+    movl %eax, %cr0
+
+jump_to_64bit:
+    # We are now in 32-bit compatibility mode. To enter 64-bit mode, we need to
+    # load a 64-bit code segment into our GDT.
+    lgdtl gdt64_ptr
+    # Set CS to a 64-bit segment and jump to 64-bit code.
+    ljmpl $(code64_desc - gdt64_start), $ram64_start

--- a/src/asm/ram64.s
+++ b/src/asm/ram64.s
@@ -3,11 +3,6 @@
 .code64
 
 ram64_start:
-    # Indicate (via serial) that we are in long/64-bit mode
-    movw $0x3f8, %dx
-    movb $'L', %al
-    outb %al, %dx
-
     # Setup the stack (at the end of our RAM region)
     movq $ram_max, %rsp
 

--- a/src/asm/ram64.s
+++ b/src/asm/ram64.s
@@ -1,10 +1,15 @@
 .section .text, "ax"
-.global ram64_start
+.global linux64_start
 .code64
+
+linux64_start:
+    # Zero out %rdi, its value is unspecificed in the Linux Boot Protocol.
+    xorq %rdi, %rdi
 
 ram64_start:
     # Setup the stack (at the end of our RAM region)
     movq $ram_max, %rsp
 
+    # PVH start_info is in %rdi, the first paramter of the System V ABI.
     # BootParams are in %rsi, the second paramter of the System V ABI.
     jmp rust64_start

--- a/src/asm/ram64.s
+++ b/src/asm/ram64.s
@@ -11,4 +11,5 @@ ram64_start:
     # Setup the stack (at the end of our RAM region)
     movq $ram_max, %rsp
 
+    # BootParams are in %rsi, the second paramter of the System V ABI.
     jmp rust64_start

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -1,0 +1,187 @@
+use core::mem;
+
+use crate::common;
+
+// Common data needed for all boot paths
+pub trait Info {
+    // Starting address of the Root System Descriptor Pointer
+    fn rsdp_addr(&self) -> u64;
+    // The kernel command line (not including null terminator)
+    fn cmdline(&self) -> &[u8];
+    // Methods to access the E820 Memory map
+    fn num_entries(&self) -> u8;
+    fn entry(&self, idx: u8) -> E820Entry;
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C, packed)]
+pub struct E820Entry {
+    pub addr: u64,
+    pub size: u64,
+    pub entry_type: u32,
+}
+
+impl E820Entry {
+    pub const RAM_TYPE: u32 = 1;
+}
+
+// The so-called "zeropage"
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+pub struct Params {
+    screen_info: ScreenInfo,        // 0x000
+    apm_bios_info: ApmBiosInfo,     // 0x040
+    _pad2: [u8; 4],                 // 0x054
+    tboot_addr: u64,                // 0x058
+    ist_info: IstInfo,              // 0x060
+    pub acpi_rsdp_addr: u64,        // 0x070
+    _pad3: [u8; 8],                 // 0x078
+    hd0_info: HdInfo,               // 0x080 - obsolete
+    hd1_info: HdInfo,               // 0x090 - obsolete
+    sys_desc_table: SysDescTable,   // 0x0a0 - obsolete
+    olpc_ofw_header: OlpcOfwHeader, // 0x0b0
+    ext_ramdisk_image: u32,         // 0x0c0
+    ext_ramdisk_size: u32,          // 0x0c4
+    ext_cmd_line_ptr: u32,          // 0x0c8
+    _pad4: [u8; 0x74],              // 0x0cc
+    edd_info: EdidInfo,             // 0x140
+    efi_info: EfiInfo,              // 0x1c0
+    alt_mem_k: u32,                 // 0x1e0
+    scratch: u32,                   // 0x1e4
+    e820_entries: u8,               // 0x1e8
+    eddbuf_entries: u8,             // 0x1e9
+    edd_mbr_sig_buf_entries: u8,    // 0x1ea
+    kbd_status: u8,                 // 0x1eb
+    secure_boot: u8,                // 0x1ec
+    _pad5: [u8; 2],                 // 0x1ed
+    sentinel: u8,                   // 0x1ef
+    _pad6: [u8; 1],                 // 0x1f0
+    pub hdr: Header,                // 0x1f1
+    _pad7: [u8; 0x290 - HEADER_END],
+    edd_mbr_sig_buffer: [u32; 16], // 0x290
+    e820_table: [E820Entry; 128],  // 0x2d0
+    _pad8: [u8; 0x30],             // 0xcd0
+    eddbuf: [EddInfo; 6],          // 0xd00
+    _pad9: [u8; 0x114],            // 0xeec
+}
+
+impl Default for Params {
+    fn default() -> Self {
+        // SAFETY: Struct consists entirely of primitive integral types.
+        unsafe { mem::zeroed() }
+    }
+}
+
+impl Params {
+    pub fn set_entries(&mut self, info: &dyn Info) {
+        self.e820_entries = info.num_entries();
+        for i in 0..self.e820_entries {
+            self.e820_table[i as usize] = info.entry(i);
+        }
+    }
+}
+
+impl Info for Params {
+    fn rsdp_addr(&self) -> u64 {
+        self.acpi_rsdp_addr
+    }
+    fn cmdline(&self) -> &[u8] {
+        unsafe { common::from_cstring(self.hdr.cmd_line_ptr as u64) }
+    }
+    fn num_entries(&self) -> u8 {
+        self.e820_entries
+    }
+    fn entry(&self, idx: u8) -> E820Entry {
+        assert!(idx < self.num_entries());
+        self.e820_table[idx as usize]
+    }
+}
+
+const HEADER_START: usize = 0x1f1;
+const HEADER_END: usize = HEADER_START + mem::size_of::<Header>();
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C, packed)]
+pub struct Header {
+    pub setup_sects: u8,
+    pub root_flags: u16,
+    pub syssize: u32,
+    pub ram_size: u16,
+    pub vid_mode: u16,
+    pub root_dev: u16,
+    pub boot_flag: u16,
+    pub jump: u16,
+    pub header: [u8; 4],
+    pub version: u16,
+    pub realmode_swtch: u32,
+    pub start_sys_seg: u16,
+    pub kernel_version: u16,
+    pub type_of_loader: u8,
+    pub loadflags: u8,
+    pub setup_move_size: u16,
+    pub code32_start: u32,
+    pub ramdisk_image: u32,
+    pub ramdisk_size: u32,
+    pub bootsect_kludge: u32,
+    pub heap_end_ptr: u16,
+    pub ext_loader_ver: u8,
+    pub ext_loader_type: u8,
+    pub cmd_line_ptr: u32,
+    pub initrd_addr_max: u32,
+    pub kernel_alignment: u32,
+    pub relocatable_kernel: u8,
+    pub min_alignment: u8,
+    pub xloadflags: u16,
+    pub cmdline_size: u32,
+    pub hardware_subarch: u32,
+    pub hardware_subarch_data: u64,
+    pub payload_offset: u32,
+    pub payload_length: u32,
+    pub setup_data: u64,
+    pub pref_address: u64,
+    pub init_size: u32,
+    pub handover_offset: u32,
+}
+
+// Right now the stucts below are unused, so we only need them to be the correct
+// size. Update test_size_and_offset if a struct's real definition is added.
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct ScreenInfo([u8; 0x40]);
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct ApmBiosInfo([u8; 0x14]);
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct IstInfo([u8; 0x10]);
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct HdInfo([u8; 0x10]);
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct SysDescTable([u8; 0x10]);
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct OlpcOfwHeader([u8; 0x10]);
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct EdidInfo([u8; 0x80]);
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct EfiInfo([u8; 0x20]);
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct EddInfo([u8; 0x52]);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_size_and_offset() {
+        assert_eq!(mem::size_of::<Header>(), 119);
+        assert_eq!(mem::size_of::<E820Entry>(), 20);
+        assert_eq!(mem::size_of::<Params>(), 4096);
+
+        assert_eq!(offset_of!(Params, hdr), HEADER_START);
+    }
+}

--- a/src/bzimage.rs
+++ b/src/bzimage.rs
@@ -143,7 +143,7 @@ pub fn load_kernel(f: &mut dyn Read) -> Result<u64, Error> {
     f.read(&mut buf[0..512])?;
     f.read(&mut buf[512..])?;
 
-    let setup = crate::mem::MemoryRegion::from_slice(&buf[..]);
+    let setup = crate::mem::MemoryRegion::from_bytes(&mut buf[..]);
 
     if setup.read_u16(0x1fe) != 0xAA55 {
         return Err(Error::MagicMissing);

--- a/src/common.rs
+++ b/src/common.rs
@@ -33,6 +33,24 @@ macro_rules! container_of_mut {
     }};
 }
 
+// SAFETY: Requires that addr point to a static, null-terminated C-string.
+// The returned slice does not include the null-terminator.
+pub unsafe fn from_cstring(addr: u64) -> &'static [u8] {
+    if addr == 0 {
+        return &[];
+    }
+    let start = addr as *const u8;
+    let mut size: usize = 0;
+    while start.add(size).read() != 0 {
+        size += 1;
+    }
+    core::slice::from_raw_parts(start, size)
+}
+
+pub fn ascii_strip(s: &[u8]) -> &str {
+    core::str::from_utf8(s).unwrap().trim_matches(char::from(0))
+}
+
 pub fn ucs2_as_ascii_length(input: *const u16) -> usize {
     let mut len = 0;
     loop {

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -23,20 +23,21 @@ pub struct LoaderConfig {
     pub cmdline: [u8; 4096],
 }
 
+#[derive(Debug)]
 pub enum Error {
-    FileError,
-    BzImageError,
+    FileError(fat::Error),
+    BzImageError(bzimage::Error),
 }
 
 impl From<fat::Error> for Error {
-    fn from(_: fat::Error) -> Error {
-        Error::FileError
+    fn from(e: fat::Error) -> Error {
+        Error::FileError(e)
     }
 }
 
 impl From<bzimage::Error> for Error {
-    fn from(_: bzimage::Error) -> Error {
-        Error::BzImageError
+    fn from(e: bzimage::Error) -> Error {
+        Error::BzImageError(e)
     }
 }
 

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -14,6 +14,7 @@
 
 use crate::{
     bzimage,
+    common::ascii_strip,
     fat::{self, Read},
 };
 
@@ -102,10 +103,6 @@ fn parse_entry(f: &mut fat::File) -> Result<LoaderConfig, fat::Error> {
     }
 
     Ok(loader_config)
-}
-
-fn ascii_strip(s: &[u8]) -> &str {
-    unsafe { core::str::from_utf8_unchecked(&s) }.trim_matches(char::from(0))
 }
 
 const ENTRY_DIRECTORY: &str = "/loader/entries/";

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,80 +76,65 @@ fn enable_sse() {
 const VIRTIO_PCI_VENDOR_ID: u16 = 0x1af4;
 const VIRTIO_PCI_BLOCK_DEVICE_ID: u16 = 0x1042;
 
-fn boot_from_device(device: &mut block::VirtioBlockDevice) -> bool {
-    match device.init() {
-        Err(_) => {
-            log!("Error configuring block device");
+fn boot_from_device(device: &mut block::VirtioBlockDevice, info: &dyn boot::Info) -> bool {
+    if let Err(err) = device.init() {
+        log!("Error configuring block device: {:?}", err);
+        return false;
+    }
+    log!(
+        "Virtio block device configured. Capacity: {} sectors",
+        device.get_capacity()
+    );
+
+    let (start, end) = match part::find_efi_partition(device) {
+        Ok(p) => p,
+        Err(err) => {
+            log!("Failed to find EFI partition: {:?}", err);
             return false;
         }
-        Ok(_) => log!(
-            "Virtio block device configured. Capacity: {} sectors",
-            device.get_capacity()
-        ),
+    };
+    log!("Found EFI partition");
+
+    let mut f = fat::Filesystem::new(device, start, end);
+    if let Err(err) = f.init() {
+        log!("Failed to create filesystem: {:?}", err);
+        return false;
     }
-
-    let mut f;
-
-    match part::find_efi_partition(device) {
-        Ok((start, end)) => {
-            log!("Found EFI partition");
-            f = fat::Filesystem::new(device, start, end);
-            if f.init().is_err() {
-                log!("Failed to create filesystem");
-                return false;
-            }
-        }
-        Err(_) => {
-            log!("Failed to find EFI partition");
-            return false;
-        }
-    }
-
     log!("Filesystem ready");
 
-    let jump_address;
-
-    match loader::load_default_entry(&f) {
-        Ok(addr) => {
-            jump_address = addr;
+    match loader::load_default_entry(&f, info) {
+        Ok(mut kernel) => {
+            device.reset();
+            log!("Jumping to kernel");
+            kernel.boot();
+            return true;
         }
-        Err(_) => {
-            log!("Error loading default entry. Using EFI boot.");
-            match f.open("/EFI/BOOT/BOOTX64 EFI") {
-                Ok(mut file) => {
-                    log!("Found bootloader (BOOTX64.EFI)");
-                    let mut l = pe::Loader::new(&mut file);
-                    match l.load(0x20_0000) {
-                        Ok((a, size)) => {
-                            log!("Executable loaded");
-                            efi::efi_exec(a, 0x20_0000, size, &f, device);
-                            return true;
-                        }
-                        Err(e) => {
-                            match e {
-                                pe::Error::FileError => log!("File error"),
-                                pe::Error::InvalidExecutable => log!("Invalid executable"),
-                            }
-                            return false;
-                        }
-                    }
-                }
-                Err(_) => {
-                    log!("Failed to find bootloader");
-                    return false;
-                }
-            }
-        }
+        Err(err) => log!("Error loading default entry: {:?}", err),
     }
 
+    log!("Using EFI boot.");
+    let mut file = match f.open("/EFI/BOOT/BOOTX64 EFI") {
+        Ok(file) => file,
+        Err(err) => {
+            log!("Failed to load default EFI binary: {:?}", err);
+            return false;
+        }
+    };
+    log!("Found bootloader (BOOTX64.EFI)");
+
+    let mut l = pe::Loader::new(&mut file);
+    let load_addr = 0x20_0000;
+    let (entry_addr, size) = match l.load(load_addr) {
+        Ok(load_info) => load_info,
+        Err(err) => {
+            log!("Error loading executable: {:?}", err);
+            return false;
+        }
+    };
+
     device.reset();
-
-    log!("Jumping to kernel");
-
-    // Rely on x86 C calling convention where second argument is put into %rsi register
-    let ptr = jump_address as *const ();
-    let code: extern "C" fn(u64, u64) = unsafe { core::mem::transmute(ptr) };
-    (code)(0 /* dummy value */, bzimage::ZERO_PAGE_START as u64);
+    log!("Executable loaded");
+    efi::efi_exec(entry_addr, 0x20_0000, size, info, &f, device);
     true
 }
 
@@ -175,7 +160,7 @@ fn run(info: &dyn boot::Info) -> ! {
             let mut pci_transport = pci::VirtioPciTransport::new(pci_device);
             block::VirtioBlockDevice::new(&mut pci_transport);
             let mut device = block::VirtioBlockDevice::new(&mut pci_transport);
-            boot_from_device(&mut device)
+            boot_from_device(&mut device, info)
         },
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,9 +153,16 @@ fn boot_from_device(device: &mut block::VirtioBlockDevice) -> bool {
     true
 }
 
-#[cfg_attr(not(test), no_mangle)]
-pub extern "C" fn rust64_start() -> ! {
-    log!("\nStarting..");
+#[no_mangle]
+pub extern "C" fn rust64_start(_rdi: *const (), rsi: Option<&boot::Params>) -> ! {
+    if let Some(boot_params) = rsi {
+        log!("\nBooting via Linux Boot Protocol");
+        run(boot_params)
+    }
+    panic!("Unable to determine boot protocol")
+}
+
+fn run(info: &dyn boot::Info) -> ! {
     enable_sse();
     paging::setup();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,11 @@ fn boot_from_device(device: &mut block::VirtioBlockDevice, info: &dyn boot::Info
 }
 
 #[no_mangle]
-pub extern "C" fn rust64_start(_rdi: *const (), rsi: Option<&boot::Params>) -> ! {
+pub extern "C" fn rust64_start(rdi: Option<&pvh::StartInfo>, rsi: Option<&boot::Params>) -> ! {
+    if let Some(start_info) = rdi {
+        log!("\nBooting via PVH Boot Protocol");
+        run(start_info)
+    }
     if let Some(boot_params) = rsi {
         log!("\nBooting via Linux Boot Protocol");
         run(boot_params)

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,7 @@ fn boot_from_device(device: &mut block::VirtioBlockDevice) -> bool {
 pub extern "C" fn rust64_start() -> ! {
     log!("\nStarting..");
     enable_sse();
-    paging::MANAGER.borrow_mut().setup();
+    paging::setup();
 
     pci::print_bus();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ mod common;
 #[cfg(not(test))]
 mod asm;
 mod block;
+mod boot;
 mod bzimage;
 mod efi;
 mod fat;

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ mod paging;
 mod part;
 mod pci;
 mod pe;
+mod pvh;
 mod virtio;
 
 #[cfg(all(not(test), feature = "log-panic"))]

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -22,16 +22,21 @@ pub struct MemoryRegion {
 }
 
 impl MemoryRegion {
-    pub fn new(base: u64, length: u64) -> MemoryRegion {
+    pub const fn new(base: u64, length: u64) -> MemoryRegion {
         MemoryRegion { base, length }
     }
 
     /// Take a slice and turn it into a region of memory
-    pub fn from_slice<T>(data: &[T]) -> MemoryRegion {
+    pub fn from_bytes(data: &mut [u8]) -> MemoryRegion {
         MemoryRegion {
             base: data.as_ptr() as u64,
-            length: (data.len() * core::mem::size_of::<T>()) as u64,
+            length: data.len() as u64,
         }
+    }
+
+    // Expose the entire region as a byte slice
+    pub fn as_bytes(&mut self) -> &mut [u8] {
+        self.as_mut_slice(0, self.length)
     }
 
     /// Expose a section of the memory region as a slice

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -1,56 +1,51 @@
-use atomic_refcell::AtomicRefCell;
 use x86_64::{
     registers::control::Cr3,
     structures::paging::{PageSize, PageTable, PageTableFlags, PhysFrame, Size2MiB},
     PhysAddr,
 };
 
-// This is the number of GiB we will identity map.
+// Amount of memory we identity map in setup(), max 512 GiB.
 const ADDRESS_SPACE_GIB: usize = 4;
 
-pub static MANAGER: AtomicRefCell<Manager> = AtomicRefCell::new(Manager::new());
-pub struct Manager {
-    l4: PageTable,
-    l3: PageTable,
-    l2s: [PageTable; ADDRESS_SPACE_GIB],
-}
+// Put the Page Tables in static muts to make linking easier
+#[no_mangle]
+static mut L4_TABLE: PageTable = PageTable::new();
+#[no_mangle]
+static mut L3_TABLE: PageTable = PageTable::new();
+#[no_mangle]
+static mut L2_TABLES: [PageTable; ADDRESS_SPACE_GIB] = [PageTable::new(); ADDRESS_SPACE_GIB];
 
-impl Manager {
-    const fn new() -> Self {
-        Manager {
-            l4: PageTable::new(),
-            l3: PageTable::new(),
-            l2s: [PageTable::new(); ADDRESS_SPACE_GIB],
+pub fn setup() {
+    // SAFETY: This function is idempontent and only writes to static memory and
+    // CR3. Thus, it is safe to run multiple times or on multiple threads.
+    let (l4, l3, l2s) = unsafe { (&mut L4_TABLE, &mut L3_TABLE, &mut L2_TABLES) };
+    log!("Setting up {} GiB identity mapping", ADDRESS_SPACE_GIB);
+    let pt_flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
+
+    // Setup Identity map using L2 huge pages
+    let mut next_addr = PhysAddr::new(0);
+    for l2 in l2s.iter_mut() {
+        for l2e in l2.iter_mut() {
+            l2e.set_addr(next_addr, pt_flags | PageTableFlags::HUGE_PAGE);
+            next_addr += Size2MiB::SIZE;
         }
     }
 
-    pub fn setup(&mut self) {
-        log!("Setting up {} GiB identity mapping", ADDRESS_SPACE_GIB);
-
-        let pt_flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
-        // Setup Identity map using L2 huge pages
-        let mut next_addr = PhysAddr::new(0);
-        for l2 in self.l2s.iter_mut() {
-            for l2e in l2.iter_mut() {
-                l2e.set_addr(next_addr, pt_flags | PageTableFlags::HUGE_PAGE);
-                next_addr += Size2MiB::SIZE;
-            }
-        }
-
-        // Point L3 at L2s
-        for (i, l2) in self.l2s.iter().enumerate() {
-            self.l3[i].set_addr(phys_addr(l2), pt_flags);
-        }
-
-        // Point L4 at L3
-        self.l4[0].set_addr(phys_addr(&self.l3), pt_flags);
-
-        // Point Cr3 at PML4
-        let cr3_flags = Cr3::read().1;
-        let pml4t_frame = PhysFrame::from_start_address(phys_addr(&self.l4)).unwrap();
-        unsafe { Cr3::write(pml4t_frame, cr3_flags) };
-        log!("Page tables setup");
+    // Point L3 at L2s
+    for (i, l2) in l2s.iter().enumerate() {
+        l3[i].set_addr(phys_addr(l2), pt_flags);
     }
+
+    // Point L4 at L3
+    l4[0].set_addr(phys_addr(l3), pt_flags);
+
+    // Point Cr3 at L4
+    let (cr3_frame, cr3_flags) = Cr3::read();
+    let l4_frame = PhysFrame::from_start_address(phys_addr(l4)).unwrap();
+    if cr3_frame != l4_frame {
+        unsafe { Cr3::write(l4_frame, cr3_flags) };
+    }
+    log!("Page tables setup");
 }
 
 // Map a virtual address to a PhysAddr (assumes identity mapping)

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -60,7 +60,7 @@ impl<'a> Loader<'a> {
             Err(_) => return Err(Error::FileError),
         }
 
-        let dos_region = MemoryRegion::from_slice(&data);
+        let dos_region = MemoryRegion::from_bytes(&mut data);
 
         // 'MZ' magic
         if dos_region.read_u16(0) != 0x5a4d {
@@ -74,7 +74,7 @@ impl<'a> Loader<'a> {
             return Err(Error::InvalidExecutable);
         }
 
-        let pe_region = MemoryRegion::from_slice(&data[pe_header_offset as usize..]);
+        let pe_region = MemoryRegion::from_bytes(&mut data[pe_header_offset as usize..]);
 
         // The Microsoft specification uses offsets relative to the COFF area
         // which is 4 after the signature (so all offsets are +4 relative to the spec)
@@ -91,7 +91,8 @@ impl<'a> Loader<'a> {
         self.num_sections = pe_region.read_u16(6);
 
         let optional_header_size = pe_region.read_u16(20);
-        let optional_region = MemoryRegion::from_slice(&data[(24 + pe_header_offset) as usize..]);
+        let optional_region =
+            MemoryRegion::from_bytes(&mut data[(24 + pe_header_offset) as usize..]);
 
         // Only support x86-64 EFI
         if optional_region.read_u16(0) != 0x20b {
@@ -177,7 +178,7 @@ impl<'a> Loader<'a> {
                 let l: &mut [u8] = loaded_region
                     .as_mut_slice(u64::from(section.virt_address), u64::from(section_size));
 
-                let reloc_region = MemoryRegion::from_slice(l);
+                let reloc_region = MemoryRegion::from_bytes(l);
 
                 let mut section_bytes_remaining = section_size;
                 let mut offset = 0;

--- a/src/pvh.rs
+++ b/src/pvh.rs
@@ -1,0 +1,55 @@
+use crate::{
+    boot::{E820Entry, Info},
+    common,
+};
+
+// Structures from xen/include/public/arch-x86/hvm/start_info.h
+#[derive(Debug)]
+#[repr(C)]
+pub struct StartInfo {
+    magic: [u8; 4],
+    version: u32,
+    flags: u32,
+    nr_modules: u32,
+    modlist_paddr: u64,
+    cmdline_paddr: u64,
+    rsdp_paddr: u64,
+    memmap_paddr: u64,
+    memmap_entries: u32,
+    _pad: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+struct MemMapEntry {
+    addr: u64,
+    size: u64,
+    entry_type: u32,
+    _pad: u32,
+}
+
+impl Info for StartInfo {
+    fn rsdp_addr(&self) -> u64 {
+        self.rsdp_paddr
+    }
+    fn cmdline(&self) -> &[u8] {
+        unsafe { common::from_cstring(self.cmdline_paddr) }
+    }
+    fn num_entries(&self) -> u8 {
+        // memmap_paddr and memmap_entries only exist in version 1 or later
+        if self.version < 1 || self.memmap_paddr == 0 {
+            return 0;
+        }
+        self.memmap_entries as u8
+    }
+    fn entry(&self, idx: u8) -> E820Entry {
+        assert!(idx < self.num_entries());
+        let ptr = self.memmap_paddr as *const MemMapEntry;
+        let entry = unsafe { *ptr.offset(idx as isize) };
+        E820Entry {
+            addr: entry.addr,
+            size: entry.size,
+            entry_type: entry.entry_type,
+        }
+    }
+}

--- a/src/virtio.rs
+++ b/src/virtio.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 /// Virtio related errors
+#[derive(Debug)]
 pub enum Error {
     VirtioUnsupportedDevice,
     VirtioLegacyOnly,


### PR DESCRIPTION
Fixes #6 

This PR adds support for booting via the [Xen HVM direct boot ABI](https://xenbits.xen.org/docs/4.12-testing/misc/pvh.html) otherwise known as the PVH Boot Protocol.

This required significant cleanup to how we load the Linux Kernel, as the existing code wasn't doing the exact correct thing. All of the commits that _don't_ start with `pvh:` are part of this cleanup. The commits that _do_ start with `pvh:` specifically address adding PVH support (including the transition for 32-bit to 64-bit mode).

This allows our firmware to be used with QEMU's `-kernel` option. This can be invoked like:
```
qemu-system-x86_64
-machine type=q35,accel=kvm \
-cpu host \
-smp 1 \
-m 1024 \
-display none \
-serial stdio \
-kernel target/target/release/hypervisor-fw \
-drive file=clear-28660-kvm.img,format=raw,if=none,id=boot-drive \
-device virtio-blk-pci,drive=boot-drive,disable-legacy=on
```

Also, as `cloud-hypervisor` supports loading PVH ELF binaries, the PVH entry point will also be used when using `cloud-hypervisor`'s `--kernel` option. This also means that no current hypervisors will use the Linux Boot Protocol path.

Signed-off-by: Joe Richey <joerichey@google.com>