### PR TITLE
serial: Fix bug with nested logging

### DIFF
--- a/src/efi/console.rs
+++ b/src/efi/console.rs
@@ -52,7 +52,7 @@ pub extern "win64" fn stdout_output_string(
     message: *mut Char16,
 ) -> Status {
     use core::fmt::Write;
-    let mut serial = crate::serial::SERIAL.borrow_mut();
+    let mut serial = crate::serial::Serial;
     let mut string_end = false;
 
     loop {


### PR DESCRIPTION
The current serial implementation will panic if you log! within a log!
statement. For example, the following code panics:

```rust
fn foo() {
	log!("foo: {}", bar());
}

fn bar() -> u64 {
	log!("bar");
	42
}
```

We change the implementation to have the `PORT` be static rather than
the entire `Serial` structure.