### PR TITLE
block: Move next_head to the head of DriverState

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -69,10 +69,10 @@ pub struct VirtioBlockDevice<'a> {
 #[repr(align(64))]
 #[derive(Default)]
 struct DriverState {
+    next_head: usize,
     descriptors: [Desc; QUEUE_SIZE],
     avail: AvailRing,
     used: UsedRing,
-    next_head: usize,
 }
 
 pub enum Error {


### PR DESCRIPTION
While event_idx is enabled for vhost_user_block backend, avail_event
will be update. Refer to virtio spec 1.1, it is the last element in
virtqueue used ring, compared to DriverState defined in src/block.rs,
avail_event is at the same position with next_head which is ajacent to
used: UsedRing. next_head is calculated in request method each time once
a descriptor chain is built. However, when avali_event is update in
vhost_user_block backend, next_head will be overwritten, which mess
things up, and it's failed to boot guest from vhost_user_block backend
finally. Move it to the head of DriverState to avoid the issue.

Fix #33 

Signed-off-by: Cathy Zhang <cathy.zhang@intel.com>