### PR TITLE
main, block: Remove device.reset()

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -123,10 +123,6 @@ impl<'a> VirtioBlockDevice<'a> {
         }
     }
 
-    pub fn reset(&self) {
-        self.transport.reset()
-    }
-
     pub fn init(&mut self) -> Result<(), VirtioError> {
         const VIRTIO_SUBSYSTEM_BLOCK: u32 = 0x2;
         const VIRTIO_F_VERSION_1: u64 = 1 << 32;

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,6 @@ fn boot_from_device(device: &mut block::VirtioBlockDevice, info: &dyn boot::Info
 
     match loader::load_default_entry(&f, info) {
         Ok(mut kernel) => {
-            device.reset();
             log!("Jumping to kernel");
             kernel.boot();
             return true;
@@ -133,7 +132,6 @@ fn boot_from_device(device: &mut block::VirtioBlockDevice, info: &dyn boot::Info
         }
     };
 
-    device.reset();
     log!("Executable loaded");
     efi::efi_exec(entry_addr, 0x20_0000, size, info, &f, device);
     true


### PR DESCRIPTION
There is no need to reset the device as Cloud Hypervisor supports device
reset itself (so the booted kernel will correctly reset the device on
boot.)

In particular resetting the block device prior to booting via EFI breaks
the EFI boot.

Fixes: #35

Signed-off-by: Rob Bradford <robert.bradford@intel.com>