### PR TITLE
serial: Use external uart_16550 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "atomic_refcell 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "r-efi 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uart_16550 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86_64 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -29,6 +30,15 @@ dependencies = [
 name = "r-efi"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "uart_16550"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86_64 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "x86_64"
@@ -44,4 +54,5 @@ dependencies = [
 "checksum bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed8765909f9009617974ab6b7d332625b320b33c326b1e9321382ef1999b5d56"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum r-efi 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f2c7f9e57367053a4c9d2f235e715b7a4fa8b774b78eb3e477b2345dc2bb33d"
+"checksum uart_16550 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e983688170873ec9a3f21a6afc751fb706cf02836ed9d28a68d2e247dff7ae52"
 "checksum x86_64 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4e6a3f047ad0844d3b4794f34d1095aefb918241064663d4163db8c7d4a76edf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ bitflags = "1.2"
 x86_64 = "0.9"
 atomic_refcell = "0.1"
 r-efi = "2.1.0"
-
+uart_16550 = "0.2.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,6 +140,8 @@ fn boot_from_device(device: &mut block::VirtioBlockDevice, info: &dyn boot::Info
 
 #[no_mangle]
 pub extern "C" fn rust64_start(rdi: Option<&pvh::StartInfo>, rsi: Option<&boot::Params>) -> ! {
+    serial::PORT.borrow_mut().init();
+
     if let Some(start_info) = rdi {
         log!("\nBooting via PVH Boot Protocol");
         run(start_info)

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -18,20 +18,15 @@
 use core::fmt;
 
 use atomic_refcell::AtomicRefCell;
-use x86_64::instructions::port::PortWriteOnly;
+use uart_16550::SerialPort;
 
 // We use COM1 as it is the standard first serial port.
-static PORT: AtomicRefCell<PortWriteOnly<u8>> = AtomicRefCell::new(PortWriteOnly::new(0x3f8));
+pub static PORT: AtomicRefCell<SerialPort> = AtomicRefCell::new(unsafe { SerialPort::new(0x3f8) });
 
 pub struct Serial;
-
 impl fmt::Write for Serial {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        let mut port = PORT.borrow_mut();
-        for b in s.bytes() {
-            unsafe { port.write(b) }
-        }
-        Ok(())
+        PORT.borrow_mut().write_str(s)
     }
 }
 


### PR DESCRIPTION
When trying to run this on various hypervisors (QEMU, GCE, etc...), I
noticed that our serial implementation is not very robust.  We can
start in the wrong mode or drop bytes, as we do not properly observe
the status bits or setup the configuration registers.

Instead of doing this ourselevs, we just use an external crate. Note
that this create is made by the same people as x86_64, and only has
that crate as a dependancy.

Signed-off-by: Joe Richey <joerichey@google.com>