### PR TITLE
Use -Zbuild-std

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,15 @@ install:
   - rustup component add clippy
   - rustup component add rustfmt
   - rustup component add rust-src
-  - cargo install cargo-xbuild
   - sudo apt-get install -y mtools
   - wget https://download.clearlinux.org/releases/28660/clear/clear-28660-kvm.img.xz
   - unxz clear-28660-kvm.img.xz
   - ./make-test-disks.sh
 
 script:
-  - cargo xbuild --release --target target.json
-  - cargo xclippy --target target.json
+  - cargo build --target target.json -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
+  - cargo build --release --target target.json -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
+  - cargo clippy --target target.json -Zbuild-std=core
   - cargo clippy --all-targets --all-features
   - cargo fmt --all -- --check
   - cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 # needed here to make "cargo check" and "cargo clippy" run without errors.
 [profile.dev]
 panic = "abort"
-lto = true
 
 [profile.release]
 panic = "abort"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ all the way into the OS.
 
 To compile:
 
-cargo xbuild --release --target target.json
+cargo build --release --target target.json -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
 
 The result will be in:
 

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -3,11 +3,8 @@ set -xeuf
 
 source "${CARGO_HOME:-$HOME/.cargo}/env"
 
-XBUILD_VERSION="0.6.2"
-cargo install cargo-xbuild --version $XBUILD_VERSION
-
 rustup component add rust-src
-cargo xbuild --release --target target.json
+cargo build --release --target target.json -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
 
 CH_VERSION="v0.8.0"
 CH_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/$CH_VERSION/cloud-hypervisor"

--- a/src/asm/ram32.s
+++ b/src/asm/ram32.s
@@ -1,4 +1,5 @@
 .section .text32, "ax"
+.global ram32_start
 .code32
 
 ram32_start:

--- a/target.json
+++ b/target.json
@@ -1,6 +1,6 @@
 {
   "llvm-target": "x86_64-unknown-none",
-  "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   "arch": "x86_64",
   "target-endian": "little",
   "target-pointer-width": "64",


### PR DESCRIPTION
Fixes #67 

For details about the changes, see each step.

Note that the only major difference from `cargo-xbuild` is that:
  - This doesn't require and external tool
  - When not using `--release`, `libcore` and `compiler-builtins` are built in debug mode
    - This means we cannot enable LTO with debug mode anymore (but that's OK).