### PR TITLE
pe: Improve PE Loader Relocation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -127,7 +127,7 @@ fn boot_from_device(device: &mut block::VirtioBlockDevice, info: &dyn boot::Info
 
     let mut l = pe::Loader::new(&mut file);
     let load_addr = 0x20_0000;
-    let (entry_addr, size) = match l.load(load_addr) {
+    let (entry_addr, load_addr, size) = match l.load(load_addr) {
         Ok(load_info) => load_info,
         Err(err) => {
             log!("Error loading executable: {:?}", err);
@@ -136,7 +136,7 @@ fn boot_from_device(device: &mut block::VirtioBlockDevice, info: &dyn boot::Info
     };
 
     log!("Executable loaded");
-    efi::efi_exec(entry_addr, 0x20_0000, size, info, &f, device);
+    efi::efi_exec(entry_addr, load_addr, size, info, &f, device);
     true
 }
 

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -172,6 +172,8 @@ impl<'a> Loader<'a> {
             }
         }
 
+        let base_diff = address as i64 - self.image_base as i64;
+
         for section in sections {
             if &section.name[0..6] == b".reloc" {
                 let section_size = core::cmp::min(section.raw_size, section.virt_size);
@@ -196,7 +198,7 @@ impl<'a> Loader<'a> {
                         if entry_type == 10 {
                             let location = u64::from(page_rva + u32::from(entry_offset));
                             let value = loaded_region.read_u64(location);
-                            loaded_region.write_u64(location, value + (address - self.image_base));
+                            loaded_region.write_u64(location, (value as i64 + base_diff) as u64);
                         }
 
                         block_offset += 2;

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -194,7 +194,7 @@ impl<'a> Loader<'a> {
                     // Read details for block
                     let page_rva = reloc_region.read_u32(offset);
                     let block_size = reloc_region.read_u32(offset + 4);
-                    let mut block_offset = 0;
+                    let mut block_offset = 8;
                     while block_offset < block_size {
                         let entry = reloc_region.read_u16(offset + u64::from(block_offset));
 


### PR DESCRIPTION
This PR improves PE relocation support.

4c2696a and 10ef5a7 are small fixes based on the PE/COFF format specification. 4c2696a fixes the panic reported in issue #73.

794caf6 changes the loader behavior to load to the preferred address if the ImageBase in the PE header is a non-zero value.
If it is not specified, it loads at the binary at the default address `0x20_0000`.