### PR TITLE
Fix coreboot CI tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
                                 }
                                 stage ('Install system packages') {
                                         steps {
-                                                sh "sudo apt-get -y install build-essential mtools qemu-system-x86 libssl-dev pkg-config"
+                                                sh "sudo apt-get -y install build-essential mtools qemu-system-x86 libssl-dev pkg-config m4 bison flex zlib1g-dev"
                                         }
                                 }
                                 stage ('Install Rust') {

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -397,8 +397,9 @@ mod tests {
         test_boot(BIONIC_IMAGE_NAME, &UbuntuCloudInit {}, spawn_qemu)
     }
 
-    // Does not currently work:
-    // #[test]
+    // Currently works on coreboot only:
+    #[test]
+    #[cfg(feature = "coreboot")]
     fn test_boot_qemu_focal() {
         test_boot(FOCAL_IMAGE_NAME, &UbuntuCloudInit {}, spawn_qemu)
     }


### PR DESCRIPTION
I saw my previous PR #74 passed all CI tests, but changes to Jenkinsfile (476060c0d4fed9b442913394de450ddcfebd6dc4) did not have effects. Some of the missing coreboot build dependencies make CI fail from merged PR #74.
This PR fixes this CI fail and enables an integration test with QEMU Ubuntu Focal for coreboot.