### PR TITLE
efi: Add GlobalAlloc and EFI Variable Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ install:
   - ./make-test-disks.sh
 
 script:
-  - cargo build --target target.json -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
-  - cargo build --release --target target.json -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
-  - cargo clippy --target target.json -Zbuild-std=core
+  - cargo build --target target.json -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
+  - cargo build --release --target target.json -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
+  - cargo clippy --target target.json -Zbuild-std=core,alloc
   - cargo clippy --all-targets --all-features
   - cargo fmt --all -- --check
   - cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ version = "0.1.0"
 dependencies = [
  "atomic_refcell",
  "bitflags",
+ "linked_list_allocator",
  "r-efi",
  "rand",
  "ssh2",
@@ -106,6 +107,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linked_list_allocator"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822add9edb1860698b79522510da17bef885171f75aa395cff099d770c609c24"
+dependencies = [
+ "spinning_top",
 ]
 
 [[package]]
@@ -247,6 +257,15 @@ name = "smallvec"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+
+[[package]]
+name = "spinning_top"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "047031d6df5f5ae0092c97aa4f6bb04cfc9c081b4cd4cb9cdb38657994279a00"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "ssh2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ x86_64 = "0.13.1"
 atomic_refcell = "0.1"
 r-efi = "3.2.0"
 uart_16550 = "0.2.10"
+linked_list_allocator = "0.8.11"
 
 [dev-dependencies]
 rand = "0.8.2"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ all the way into the OS.
 
 To compile:
 
-cargo build --release --target target.json -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
+cargo build --release --target target.json -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
 
 The result will be in:
 

--- a/run_coreboot_integration_tests.sh
+++ b/run_coreboot_integration_tests.sh
@@ -4,7 +4,7 @@ set -xeuf
 source "${CARGO_HOME:-$HOME/.cargo}/env"
 
 rustup component add rust-src
-cargo build --release --target target.json -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem --features "coreboot"
+cargo build --release --target target.json -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem --features "coreboot"
 
 FW_BIN="$(pwd)/target/target/release/hypervisor-fw"
 

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -4,7 +4,7 @@ set -xeuf
 source "${CARGO_HOME:-$HOME/.cargo}/env"
 
 rustup component add rust-src
-cargo build --release --target target.json -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
+cargo build --release --target target.json -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
 
 CH_VERSION="v0.8.0"
 CH_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/$CH_VERSION/cloud-hypervisor"

--- a/src/efi/var.rs
+++ b/src/efi/var.rs
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021 Akira Moroo
+
+#[cfg(not(test))]
+extern crate alloc;
+
+#[cfg(not(test))]
+use alloc::vec::Vec;
+
+use r_efi::efi;
+
+#[derive(Debug)]
+struct Descriptor {
+    name: Vec<u16>,
+    guid: efi::Guid,
+    attr: u32,
+    data: Vec<u8>,
+}
+
+impl Descriptor {
+    const fn new() -> Self {
+        Self {
+            name: Vec::new(),
+            guid: efi::Guid::from_fields(0, 0, 0, 0, 0, &[0; 6]),
+            attr: 0,
+            data: Vec::new(),
+        }
+    }
+}
+
+pub struct VariableAllocator {
+    allocations: Vec<Descriptor>,
+}
+
+impl VariableAllocator {
+    pub const fn new() -> Self {
+        Self {
+            allocations: Vec::new(),
+        }
+    }
+
+    fn find(&self, name: *const u16, guid: *const efi::Guid) -> Option<usize> {
+        if name.is_null() || guid.is_null() {
+            return None;
+        }
+        let len = crate::common::ucs2_as_ascii_length(name);
+        if len == 0 {
+            return None;
+        }
+
+        let s = unsafe { core::slice::from_raw_parts(name as *const u16, len + 1) };
+        let mut name: Vec<u16> = Vec::new();
+        name.extend_from_slice(s);
+        let guid = unsafe { &*guid };
+        for i in 0..self.allocations.len() {
+            if name == self.allocations[i].name && guid == &self.allocations[i].guid {
+                return Some(i);
+            }
+        }
+        None
+    }
+
+    pub fn get(
+        &mut self,
+        name: *const efi::Char16,
+        guid: *const efi::Guid,
+        attr: *mut u32,
+        size: *mut usize,
+        data: *mut core::ffi::c_void,
+    ) -> efi::Status {
+        if name.is_null() || guid.is_null() || size.is_null() {
+            return efi::Status::INVALID_PARAMETER;
+        }
+        let index = self.find(name, guid);
+        if index == None {
+            return efi::Status::NOT_FOUND;
+        }
+        let a = &self.allocations[index.unwrap()];
+        unsafe {
+            if *size < a.data.len() {
+                *size = a.data.len();
+                return efi::Status::BUFFER_TOO_SMALL;
+            }
+        }
+
+        assert!(!a.data.is_empty());
+        unsafe {
+            if !attr.is_null() {
+                *attr = a.attr;
+            }
+            *size = a.data.len();
+
+            let data = core::slice::from_raw_parts_mut(data as *mut u8, a.data.len());
+            data.clone_from_slice(&a.data);
+        }
+
+        efi::Status::SUCCESS
+    }
+
+    pub fn set(
+        &mut self,
+        name: *const efi::Char16,
+        guid: *const efi::Guid,
+        attr: u32,
+        size: usize,
+        data: *const core::ffi::c_void,
+    ) -> efi::Status {
+        if name.is_null() || guid.is_null() {
+            return efi::Status::INVALID_PARAMETER;
+        }
+        let len = crate::common::ucs2_as_ascii_length(name);
+        if len == 0 {
+            return efi::Status::INVALID_PARAMETER;
+        }
+        let index = self.find(name, guid);
+        if index == None {
+            // new variable
+            if size == 0 {
+                return efi::Status::NOT_FOUND;
+            }
+            if data.is_null() {
+                return efi::Status::INVALID_PARAMETER;
+            }
+            let mut a = Descriptor::new();
+            let name = unsafe { core::slice::from_raw_parts(name as *const u16, len + 1) };
+            a.name.extend_from_slice(name);
+            a.guid = unsafe { *guid };
+            a.attr = attr & !efi::VARIABLE_APPEND_WRITE;
+            let src = unsafe { core::slice::from_raw_parts(data as *const u8, size) };
+            a.data.extend_from_slice(src);
+
+            self.allocations.push(a);
+
+            return efi::Status::SUCCESS;
+        }
+
+        if attr & efi::VARIABLE_APPEND_WRITE != 0 {
+            // append to existing variable
+            if size == 0 {
+                return efi::Status::SUCCESS;
+            }
+            if data.is_null() {
+                return efi::Status::INVALID_PARAMETER;
+            }
+            let a = &mut self.allocations[index.unwrap()];
+            let attr = attr & !efi::VARIABLE_APPEND_WRITE;
+            if a.attr != attr {
+                return efi::Status::INVALID_PARAMETER;
+            }
+            let src = unsafe { core::slice::from_raw_parts(data as *const u8, size) };
+            a.data.extend_from_slice(src);
+            return efi::Status::SUCCESS;
+        }
+
+        if attr == 0 || size == 0 {
+            self.allocations.remove(index.unwrap());
+            return efi::Status::SUCCESS;
+        }
+
+        let a = &mut self.allocations[index.unwrap()];
+        if attr != a.attr {
+            return efi::Status::INVALID_PARAMETER;
+        }
+        a.data.clear();
+        let src = unsafe { core::slice::from_raw_parts(data as *const u8, size) };
+        a.data.extend_from_slice(src);
+
+        efi::Status::SUCCESS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VariableAllocator;
+    use r_efi::efi;
+
+    const NAME: [efi::Char16; 5] = [116, 101, 115, 116, 0];
+    const GUID: efi::Guid = efi::Guid::from_fields(1, 2, 3, 4, 5, &[6; 6]);
+    const ATTR: u32 = efi::VARIABLE_BOOTSERVICE_ACCESS | efi::VARIABLE_RUNTIME_ACCESS;
+
+    fn set_initial_variable(allocator: &mut VariableAllocator, data: &[u8]) {
+        let status = allocator.set(
+            NAME.as_ptr(),
+            &GUID,
+            ATTR,
+            data.len(),
+            data.as_ptr() as *const core::ffi::c_void,
+        );
+
+        assert_eq!(status, efi::Status::SUCCESS);
+        assert_eq!(allocator.allocations[0].name, NAME);
+        assert_eq!(allocator.allocations[0].guid, GUID);
+        assert_eq!(allocator.allocations[0].attr, ATTR);
+        assert_eq!(allocator.allocations[0].data, data);
+    }
+
+    #[test]
+    fn test_new() {
+        let mut allocator = VariableAllocator::new();
+        set_initial_variable(&mut allocator, &[1, 2, 3]);
+    }
+
+    #[test]
+    fn test_overwrite() {
+        let mut allocator = VariableAllocator::new();
+        set_initial_variable(&mut allocator, &[1, 2, 3]);
+
+        let data: [u8; 5] = [4, 5, 6, 7, 8];
+        let attr = ATTR;
+        let status = allocator.set(
+            NAME.as_ptr(),
+            &GUID,
+            attr,
+            data.len(),
+            data.as_ptr() as *const core::ffi::c_void,
+        );
+
+        assert_eq!(status, efi::Status::SUCCESS);
+        assert_eq!(allocator.allocations[0].name, NAME);
+        assert_eq!(allocator.allocations[0].guid, GUID);
+        assert_eq!(allocator.allocations[0].attr, attr);
+        assert_eq!(allocator.allocations[0].data, data);
+    }
+
+    #[test]
+    fn test_append() {
+        let mut allocator = VariableAllocator::new();
+        set_initial_variable(&mut allocator, &[1, 2, 3]);
+
+        let size = 0;
+        let attr = ATTR | efi::VARIABLE_APPEND_WRITE;
+        let status = allocator.set(
+            NAME.as_ptr(),
+            &GUID,
+            attr,
+            size,
+            core::ptr::null() as *const core::ffi::c_void,
+        );
+
+        assert_eq!(status, efi::Status::SUCCESS);
+        assert_eq!(allocator.allocations[0].name, NAME);
+        assert_eq!(allocator.allocations[0].guid, GUID);
+        assert_eq!(allocator.allocations[0].attr, ATTR);
+        assert_eq!(allocator.allocations[0].data, [1, 2, 3]);
+
+        let data: [u8; 5] = [4, 5, 6, 7, 8];
+        let attr = ATTR | efi::VARIABLE_APPEND_WRITE;
+        let status = allocator.set(
+            NAME.as_ptr(),
+            &GUID,
+            attr,
+            data.len(),
+            data.as_ptr() as *const core::ffi::c_void,
+        );
+
+        assert_eq!(status, efi::Status::SUCCESS);
+        assert_eq!(allocator.allocations[0].name, NAME);
+        assert_eq!(allocator.allocations[0].guid, GUID);
+        assert_eq!(allocator.allocations[0].attr, ATTR);
+        assert_eq!(allocator.allocations[0].data, [1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn test_erase() {
+        let mut allocator = VariableAllocator::new();
+        set_initial_variable(&mut allocator, &[1, 2, 3]);
+
+        let size = 0;
+        let attr = ATTR;
+        let status = allocator.set(
+            NAME.as_ptr(),
+            &GUID,
+            attr,
+            size,
+            core::ptr::null() as *const core::ffi::c_void,
+        );
+
+        assert_eq!(status, efi::Status::SUCCESS);
+        assert_eq!(allocator.allocations.is_empty(), true);
+
+        set_initial_variable(&mut allocator, &[1, 2, 3]);
+
+        let data: [u8; 5] = [4, 5, 6, 7, 8];
+        let attr = 0;
+        let status = allocator.set(
+            NAME.as_ptr(),
+            &GUID,
+            attr,
+            data.len(),
+            data.as_ptr() as *const core::ffi::c_void,
+        );
+
+        assert_eq!(status, efi::Status::SUCCESS);
+        assert_eq!(allocator.allocations.is_empty(), true);
+    }
+
+    #[test]
+    fn test_get() {
+        let mut allocator = VariableAllocator::new();
+        const DATA: [u8; 3] = [1, 2, 3];
+        set_initial_variable(&mut allocator, &DATA);
+
+        let mut data: [u8; 3] = [0; 3];
+        let mut size = data.len();
+        let mut attr = 0;
+        let status = allocator.get(
+            NAME.as_ptr(),
+            &GUID,
+            &mut attr,
+            &mut size,
+            data.as_mut_ptr() as *mut core::ffi::c_void,
+        );
+        assert_eq!(status, efi::Status::SUCCESS);
+        assert_eq!(attr, ATTR);
+        assert_eq!(size, DATA.len());
+        assert_eq!(data, DATA);
+
+        let mut data: [u8; 3] = [0; 3];
+        let mut size = data.len();
+        let status = allocator.get(
+            NAME.as_ptr(),
+            &GUID,
+            core::ptr::null_mut() as *mut u32,
+            &mut size,
+            data.as_mut_ptr() as *mut core::ffi::c_void,
+        );
+        assert_eq!(status, efi::Status::SUCCESS);
+        assert_eq!(size, DATA.len());
+        assert_eq!(data, DATA);
+
+        let mut data: [u8; 1] = [0; 1];
+        let mut size = data.len();
+        let mut attr = 0;
+        let status = allocator.get(
+            NAME.as_ptr(),
+            &GUID,
+            &mut attr,
+            &mut size,
+            data.as_mut_ptr() as *mut core::ffi::c_void,
+        );
+        assert_eq!(status, efi::Status::BUFFER_TOO_SMALL);
+        assert_eq!(attr, 0);
+        assert_eq!(size, DATA.len());
+        assert_eq!(data, [0; 1]);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(alloc_error_handler)]
 #![feature(global_asm, const_in_array_repeat_expressions)]
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]


### PR DESCRIPTION
Some vanilla Ubuntu (Bionic and Focal) boot images fail to boot because EFI variables are not supported, as mentioned in issue #77.

This PR proposes simple EFI variable support for this problem. The `VariableAllocator` provides `SetVariable ()` and `GetVariable ()` before `ExitBootServices ()` called. The EFI variables are stored in the memory and volatile after reboots even if `EFI_VARIABLE_NON_VOLATILE` is specified.

It also adds a global allocator to make heap-allocated data structures available. Since this firmware already has a page-level allocator for EFI, the heap allocator manages the only fixed size of memory given from the page allocator.

Currently, the heap is used only for the EFI variable allocator, but it may be useful for implementing other features.

However, the boot images are still not bootable from out-of-the-box because `BOOTx64.efi` tries to open `/EFI/BOOT/grubx64.efi`, which does not exist. I copied `/EFI/ubuntu/grubx64.efi` to the path as a workaround.
I tested with:
* bionic-server-cloudimg-amd64.img: Daily Build [20210222]
* focal-server-cloudimg-amd64.img: Daily Build [20210222]