### PR TITLE
efi: Improve Directory Open/Read

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -64,6 +64,17 @@ pub fn ucs2_as_ascii_length(input: *const u16) -> usize {
     len
 }
 
+pub fn ascii_length(input: &str) -> usize {
+    let mut len = 0;
+    for c in input.chars() {
+        if c == '\0' {
+            break;
+        }
+        len += 1;
+    }
+    len
+}
+
 pub fn ucs2_to_ascii(input: *const u16, output: &mut [u8]) {
     let mut i: usize = 0;
     assert!(output.len() >= ucs2_as_ascii_length(input));

--- a/src/efi/file.rs
+++ b/src/efi/file.rs
@@ -183,7 +183,7 @@ pub extern "win64" fn set_position(_: *mut FileProtocol, _: u64) -> Status {
     Status::UNSUPPORTED
 }
 
-#[allow(unused)]
+#[repr(C)]
 struct FileInfo {
     size: u64,
     file_size: u64,

--- a/src/efi/file.rs
+++ b/src/efi/file.rs
@@ -209,12 +209,16 @@ pub extern "win64" fn get_info(
             let info = info as *mut FileInfo;
 
             let wrapper = container_of!(file, FileWrapper, proto);
+            let attribute = match unsafe { &(*wrapper).node } {
+                crate::fat::Node::Directory(_) => r_efi::protocols::file::DIRECTORY,
+                crate::fat::Node::File(_) => r_efi::protocols::file::ARCHIVE,
+            };
             use crate::fat::Read;
             unsafe {
                 (*info).size = core::mem::size_of::<FileInfo>() as u64;
                 (*info).file_size = (*wrapper).node.get_size().into();
                 (*info).physical_size = (*wrapper).node.get_size().into();
-                (*info).attribute = r_efi::protocols::file::MODE_READ;
+                (*info).attribute = attribute;
             }
 
             Status::SUCCESS

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -314,6 +314,7 @@ impl<'a> Directory<'a> {
             self.offset = 0;
         }
     }
+
     pub fn open(&self, path: &str) -> Result<Node, Error> {
         let root = self.filesystem.root().unwrap();
         let dir = if is_absolute_path(path) { &root } else { self };

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -496,13 +496,14 @@ impl<'a> SectorRead for Filesystem<'a> {
 // Do a case-insensitive match on the name with the 8.3 format that you get from FAT.
 // In the FAT directory entry the "." isn't stored and any gaps are padded with " ".
 fn compare_short_name(name: &str, de: &DirectoryEntry) -> bool {
+    let name = name.trim_matches(char::from(0));
     // 8.3 (plus 1 for the separator)
     if crate::common::ascii_length(name) > 12 {
         return false;
     }
 
     let mut i = 0;
-    for (_, a) in name.as_bytes().iter().enumerate() {
+    for a in name.as_bytes().iter() {
         // Handle cases which are 11 long but not 8.3 (e.g "loader.conf")
         if i == 11 {
             return false;


### PR DESCRIPTION
This PR mainly proposes two features:
1. 3449aa1: Add open from non-root directory support
2. c43e59d: Add directory read support

Some bootloaders (e.g., `fbx64.efi` from shim) need these features to traverse the given filesystem. The rough design is based on the discussion in issue #19, which introduces `Node` enum to abstract `Directory` and `File`.

It also includes some small fixes for EFI compatibility.

Once this PR is merged, issue #19 can be closed.