### PR TITLE
Add support off-the-shelf Ubuntu image boot

### DIFF
--- a/fetch_disk_images.sh
+++ b/fetch_disk_images.sh
@@ -14,7 +14,7 @@ if [ ! -f "$CLEAR_OS_IMAGE" ]; then
 fi
 
 BIONIC_OS_IMAGE_NAME="bionic-server-cloudimg-amd64.img"
-BIONIC_OS_IMAGE_URL="https://cloudhypervisorstorage.blob.core.windows.net/images/$BIONIC_OS_IMAGE_NAME"
+BIONIC_OS_IMAGE_URL="https://cloud-images.ubuntu.com/bionic/current/$BIONIC_OS_IMAGE_NAME"
 BIONIC_OS_IMAGE="$IMAGES_DIR/$BIONIC_OS_IMAGE_NAME"
 if [ ! -f "$BIONIC_OS_IMAGE" ]; then
     pushd $IMAGES_DIR
@@ -31,7 +31,7 @@ if [ ! -f "$BIONIC_OS_RAW_IMAGE" ]; then
 fi
 
 FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64.img"
-FOCAL_OS_IMAGE_URL="https://cloudhypervisorstorage.blob.core.windows.net/images/$FOCAL_OS_IMAGE_NAME"
+FOCAL_OS_IMAGE_URL="https://cloud-images.ubuntu.com/focal/current/$FOCAL_OS_IMAGE_NAME"
 FOCAL_OS_IMAGE="$IMAGES_DIR/$FOCAL_OS_IMAGE_NAME"
 if [ ! -f "$FOCAL_OS_IMAGE" ]; then
     pushd $IMAGES_DIR

--- a/src/efi/alloc.rs
+++ b/src/efi/alloc.rs
@@ -34,7 +34,7 @@ struct Allocation {
     descriptor: MemoryDescriptor,
 }
 
-const MAX_ALLOCATIONS: usize = 32;
+const MAX_ALLOCATIONS: usize = 256;
 
 #[derive(Copy, Clone)]
 pub struct Allocator {

--- a/src/efi/alloc.rs
+++ b/src/efi/alloc.rs
@@ -187,6 +187,16 @@ impl Allocator {
         Some(new)
     }
 
+    pub fn find_free_pages(
+        &mut self,
+        allocate_type: AllocateType,
+        page_count: u64,
+        address: u64,
+    ) -> Option<u64> {
+        self.find_free_memory(allocate_type, page_count, address)
+            .map(|dest| self.allocations[dest].descriptor.physical_start)
+    }
+
     pub fn allocate_pages(
         &mut self,
         allocate_type: AllocateType,

--- a/src/efi/file.rs
+++ b/src/efi/file.rs
@@ -261,7 +261,7 @@ struct FileWrapper<'a> {
 #[repr(C)]
 pub struct FileSystemWrapper<'a> {
     hw: super::HandleWrapper,
-    fs: &'a crate::fat::Filesystem<'a>,
+    pub fs: &'a crate::fat::Filesystem<'a>,
     pub proto: SimpleFileSystemProtocol,
     pub block_part_id: Option<u32>,
 }

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -864,14 +864,6 @@ pub fn efi_exec(
         },
         file::FileDevicePathProtocol {
             device_path: DevicePathProtocol {
-                r#type: r_efi::protocols::device_path::TYPE_MEDIA,
-                sub_type: 4, // Media Path type file
-                length: [132, 0],
-            },
-            filename: [0; 64],
-        },
-        file::FileDevicePathProtocol {
-            device_path: DevicePathProtocol {
                 r#type: r_efi::protocols::device_path::TYPE_END,
                 sub_type: 0xff, // End of full path
                 length: [4, 0],
@@ -880,8 +872,7 @@ pub fn efi_exec(
         },
     ];
 
-    crate::common::ascii_to_ucs2("\\EFI\\BOOT", &mut file_paths[0].filename);
-    crate::common::ascii_to_ucs2("BOOTX64.EFI", &mut file_paths[1].filename);
+    crate::common::ascii_to_ucs2("\\EFI\\BOOT\\BOOTX64.EFI", &mut file_paths[0].filename);
 
     let wrapped_fs = file::FileSystemWrapper::new(fs, efi_part_id);
 

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -371,7 +371,9 @@ impl<'a> Directory<'a> {
     }
 
     pub fn seek(&mut self, offset: u32) -> Result<(), Error> {
-        assert_eq!(offset, 0);
+        if offset != 0 {
+            return Err(Error::Unsupported);
+        }
         self.offset = 0;
         Ok(())
     }

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -397,8 +397,7 @@ mod tests {
         test_boot(BIONIC_IMAGE_NAME, &UbuntuCloudInit {}, spawn_qemu)
     }
 
-    // Does not currently work:
-    // #[test]
+    #[test]
     fn test_boot_qemu_focal() {
         test_boot(FOCAL_IMAGE_NAME, &UbuntuCloudInit {}, spawn_qemu)
     }


### PR DESCRIPTION
This PR proposes changes to support unmodified Ubuntu image boot.
The main changes are implementing load_image (9fd3a8b) and start_image (ae7f47b) to load/start the second-stage bootloader.
I tested with:
* [Ubuntu 18.04 LTS [20210319]](https://cloud-images.ubuntu.com/bionic/20210319): bionic-server-cloudimg-amd64.img
* [Ubuntu 20.04 LTS [20210316]](https://cloud-images.ubuntu.com/focal/20210316): focal-server-cloudimg-amd64.img

Boot Flow: BOOTX64.EFI (shimx64.efi) -> fbx64.efi -> shim64.efi -> grubx64.efi -> Linux kernel.