### PR TITLE
Experimental Windows Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ panic = "abort"
 
 [profile.release]
 panic = "abort"
-lto = true
+lto = "thin"
 
 [features]
 default = ["log-serial", "log-panic"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,16 @@ pipeline {
                                                                 sh "nohup curl https://sh.rustup.rs -sSf | sh -s -- -y"
                                                         }
                                                 }
+                                                stage ('Download assets') {
+                                                        steps {
+                                                                sh "mkdir ./resources/images"
+                                                                azureDownload(storageCredentialId: 'ch-image-store',
+                                                                                          containerName: 'private-images',
+                                                                                          includeFilesPattern: 'windows-server-2019.raw',
+                                                                                          downloadType: 'container',
+                                                                                          downloadDirLoc: "./resources/images")
+                                                        }
+                                                }
                                                 stage('Run integration tests') {
                                                           steps {
                                                                   sh "./run_integration_tests.sh"
@@ -50,6 +60,16 @@ pipeline {
                                                 stage ('Install Rust') {
                                                         steps {
                                                                 sh "nohup curl https://sh.rustup.rs -sSf | sh -s -- -y"
+                                                        }
+                                                }
+                                                stage ('Download assets') {
+                                                        steps {
+                                                                sh "mkdir ./resources/images"
+                                                                azureDownload(storageCredentialId: 'ch-image-store',
+                                                                                          containerName: 'private-images',
+                                                                                          includeFilesPattern: 'windows-server-2019.raw',
+                                                                                          downloadType: 'container',
+                                                                                          downloadDirLoc: "./resources/images")
                                                         }
                                                 }
                                                 stage('Run integration tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
                                                                 sh "nohup curl https://sh.rustup.rs -sSf | sh -s -- -y"
                                                         }
                                                 }
+                                                /*
                                                 stage ('Download assets') {
                                                         steps {
                                                                 sh "mkdir ./resources/images"
@@ -34,6 +35,7 @@ pipeline {
                                                                                           downloadDirLoc: "./resources/images")
                                                         }
                                                 }
+                                                */
                                                 stage('Run integration tests') {
                                                           steps {
                                                                   sh "./run_integration_tests.sh"
@@ -62,6 +64,7 @@ pipeline {
                                                                 sh "nohup curl https://sh.rustup.rs -sSf | sh -s -- -y"
                                                         }
                                                 }
+                                                /*
                                                 stage ('Download assets') {
                                                         steps {
                                                                 sh "mkdir ./resources/images"
@@ -72,6 +75,7 @@ pipeline {
                                                                                           downloadDirLoc: "./resources/images")
                                                         }
                                                 }
+                                                */
                                                 stage('Run integration tests') {
                                                           steps {
                                                                   sh "./run_coreboot_integration_tests.sh"

--- a/layout.ld
+++ b/layout.ld
@@ -33,7 +33,7 @@ SECTIONS
   }
 
   /* Our stack grows down and is page-aligned. TODO: Add stack guard pages. */
-  .stack (NOLOAD) : ALIGN(4K) { . += 64K; }
+  .stack (NOLOAD) : ALIGN(4K) { . += 128K; }
   stack_start = .;
   /* ram32.s only maps the first 2 MiB, and that must include the stack. */
   ASSERT((. <= 2M), "Stack overflows initial identity-mapped memory region")

--- a/layout.ld
+++ b/layout.ld
@@ -20,8 +20,12 @@ SECTIONS
      later sections avoids emitting empty sections in the final binary.       */
   data_start = .;
   .rodata : { *(.rodata .rodata.*) } :ram
+  . = ALIGN(4K);
+  text_start = .;
   .text   : { *(.text .text.*)     }
   .text32 : { *(.text32)           }
+  . = ALIGN(4K);
+  text_end = .;
   .data   : { *(.data .data.*)     }
   data_size = . - data_start;
 

--- a/src/asm/ram32.s
+++ b/src/asm/ram32.s
@@ -43,6 +43,13 @@ jump_to_64bit:
     lgdtl GDT64_PTR
     # Initialize the stack pointer (Rust code always uses the stack)
     movl $stack_start, %esp
+    # Set segment registers to a 64-bit segment.
+    movw $0x10, %ax
+    movw %ax, %ds
+    movw %ax, %es
+    movw %ax, %gs
+    movw %ax, %fs
+    movw %ax, %ss
     # Set CS to a 64-bit segment and jump to 64-bit Rust code.
     # PVH start_info is in %rdi, the first paramter of the System V ABI.
     ljmpl $0x08, $rust64_start

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (C) 2021 Akira Moroo
+// Copyright (C) 2018 Google LLC
+
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::_rdtsc;
+
+const NSECS_PER_SEC: u64 = 1000000000;
+const CPU_KHZ_DEFAULT: u64 = 200;
+const PAUSE_THRESHOLD_TICKS: u64 = 150;
+
+pub fn ndelay(ns: u64) {
+    let delta = ns * CPU_KHZ_DEFAULT / NSECS_PER_SEC;
+    let mut pause_delta = 0;
+    unsafe {
+        let start = _rdtsc();
+        if delta > PAUSE_THRESHOLD_TICKS {
+            pause_delta = delta - PAUSE_THRESHOLD_TICKS;
+        }
+        while _rdtsc() - start < pause_delta {
+            asm!("pause");
+        }
+        while _rdtsc() - start < delta {}
+    }
+}
+
+pub fn udelay(us: u64) {
+    for _i in 0..us as usize {
+        ndelay(1000)
+    }
+}
+
+#[allow(dead_code)]
+pub fn mdelay(ms: u64) {
+    for _i in 0..ms as usize {
+        udelay(1000)
+    }
+}
+
+#[allow(dead_code)]
+pub fn wait_while<F>(ms: u64, cond: F) -> bool
+where
+    F: Fn() -> bool,
+{
+    let mut us = ms * 1000;
+    while cond() && us > 0 {
+        udelay(1);
+        us -= 1;
+    }
+    cond()
+}
+
+#[allow(dead_code)]
+pub fn wait_until<F>(ms: u64, cond: F) -> bool
+where
+    F: Fn() -> bool,
+{
+    let mut us = ms * 1000;
+    while !cond() && us > 0 {
+        udelay(1);
+        us -= 1;
+    }
+    cond()
+}

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -38,9 +38,9 @@ pub fn mdelay(ms: u64) {
 }
 
 #[allow(dead_code)]
-pub fn wait_while<F>(ms: u64, cond: F) -> bool
+pub fn wait_while<F>(ms: u64, mut cond: F) -> bool
 where
-    F: Fn() -> bool,
+    F: FnMut() -> bool,
 {
     let mut us = ms * 1000;
     while cond() && us > 0 {
@@ -51,9 +51,9 @@ where
 }
 
 #[allow(dead_code)]
-pub fn wait_until<F>(ms: u64, cond: F) -> bool
+pub fn wait_until<F>(ms: u64, mut cond: F) -> bool
 where
-    F: Fn() -> bool,
+    F: FnMut() -> bool,
 {
     let mut us = ms * 1000;
     while !cond() && us > 0 {

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -878,7 +878,7 @@ fn populate_allocator(info: &dyn boot::Info, image_address: u64, image_size: u64
     // Add ourselves
     ALLOCATOR.borrow_mut().allocate_pages(
         AllocateType::AllocateAddress,
-        MemoryType::RuntimeServicesCode,
+        MemoryType::RuntimeServicesData,
         1024 * 1024 / PAGE_SIZE,
         1024 * 1024,
     );

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -899,7 +899,7 @@ fn populate_allocator(info: &dyn boot::Info, image_address: u64, image_size: u64
 fn init_heap_allocator(size: usize) {
     let (status, heap_start) = ALLOCATOR.borrow_mut().allocate_pages(
         AllocateType::AllocateAnyPages,
-        MemoryType::BootServicesCode,
+        MemoryType::RuntimeServicesData,
         size as u64 / PAGE_SIZE,
         0,
     );

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -656,8 +656,9 @@ pub extern "win64" fn get_next_monotonic_count(_: *mut u64) -> Status {
     Status::DEVICE_ERROR
 }
 
-pub extern "win64" fn stall(_: usize) -> Status {
-    Status::UNSUPPORTED
+pub extern "win64" fn stall(microseconds: usize) -> Status {
+    crate::delay::udelay(microseconds as u64);
+    Status::SUCCESS
 }
 
 pub extern "win64" fn set_watchdog_timer(_: usize, _: u64, _: usize, _: *mut Char16) -> Status {

--- a/src/gdt.rs
+++ b/src/gdt.rs
@@ -25,7 +25,8 @@ bitflags::bitflags! {
         // We set ACCESSED in advance to avoid writing to the descriptor.
         const COMMON = Self::ACCESSED.bits | Self::USER_SEGMENT.bits | Self::PRESENT.bits;
         // BIT32 must be 0, all other bits (not yet mentioned) are ignored.
-        const CODE64 = Self::COMMON.bits | Self::EXECUTABLE.bits | Self::BIT64.bits;
+        const CODE64 = Self::COMMON.bits | Self::READABLE.bits | Self::EXECUTABLE.bits | Self::BIT64.bits;
+        const DATA64 = Self::COMMON.bits | Self::WRITABLE.bits | Self::BIT64.bits;
     }
 }
 
@@ -50,4 +51,4 @@ impl Pointer {
 // Our 64-bit GDT lives in RAM, so it can be accessed like any other global.
 #[no_mangle]
 static GDT64_PTR: Pointer = Pointer::new(&GDT64);
-static GDT64: [Descriptor; 2] = [Descriptor::empty(), Descriptor::CODE64];
+static GDT64: [Descriptor; 3] = [Descriptor::empty(), Descriptor::CODE64, Descriptor::DATA64];

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -227,6 +227,12 @@ mod tests {
     }
 
     #[derive(Debug)]
+    struct PasswordAuth {
+        username: String,
+        password: String,
+    }
+
+    #[derive(Debug)]
     enum SSHCommandError {
         Connection(std::io::Error),
         Handshake(ssh2::Error),
@@ -235,7 +241,11 @@ mod tests {
         Command(ssh2::Error),
     }
 
-    fn ssh_command(ip: &str, command: &str) -> Result<String, SSHCommandError> {
+    fn ssh_command_with_auth(
+        ip: &str,
+        command: &str,
+        auth: &PasswordAuth,
+    ) -> Result<String, SSHCommandError> {
         const DEFAULT_SSH_RETRIES: u8 = 6;
         const DEFAULT_SSH_TIMEOUT: u8 = 10;
 
@@ -252,7 +262,7 @@ mod tests {
                 sess.set_tcp_stream(tcp);
                 sess.handshake().map_err(SSHCommandError::Handshake)?;
 
-                sess.userauth_password("cloud", "cloud123")
+                sess.userauth_password(&auth.username, &auth.password)
                     .map_err(SSHCommandError::Authentication)?;
                 assert!(sess.authenticated());
 
@@ -279,6 +289,17 @@ mod tests {
             thread::sleep(std::time::Duration::new((timeout * counter).into(), 0));
         }
         Ok(s)
+    }
+
+    fn ssh_command(ip: &str, command: &str) -> Result<String, SSHCommandError> {
+        ssh_command_with_auth(
+            ip,
+            command,
+            &PasswordAuth {
+                username: String::from("cloud"),
+                password: String::from("cloud123"),
+            },
+        )
     }
 
     fn spawn_ch(os: &str, ci: &str, net: &GuestNetworkConfig) -> Child {
@@ -435,5 +456,70 @@ mod tests {
     #[cfg(not(feature = "coreboot"))]
     fn test_boot_ch_clear() {
         test_boot(CLEAR_IMAGE_NAME, &ClearCloudInit {}, spawn_ch)
+    }
+
+    const WINDOWS_IMAGE_NAME: &str = "windows-server-2019.raw";
+
+    fn windows_auth() -> PasswordAuth {
+        PasswordAuth {
+            username: String::from("administrator"),
+            password: String::from("Admin123"),
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "coreboot")]
+    fn test_boot_qemu_windows() {
+        let tmp_dir = TempDir::new().expect("Expect creating temporary directory to succeed");
+        let net = GuestNetworkConfig::new(COUNTER.fetch_add(1, Ordering::SeqCst) as u8);
+        let os = prepare_os_disk(&tmp_dir, WINDOWS_IMAGE_NAME);
+
+        prepare_tap(&net);
+
+        let fw = Firmware {
+            fw_type: "-bios",
+            path: "resources/coreboot/coreboot/build/coreboot.rom",
+        };
+
+        let mut c = Command::new("qemu-system-x86_64");
+        c.args(&[
+            "-machine",
+            "q35,accel=kvm",
+            "-cpu",
+            "host,-vmx",
+            fw.fw_type,
+            fw.path,
+            "-display",
+            "none",
+            "-nodefaults",
+            "-serial",
+            "stdio",
+            "-drive",
+            &format!("id=os,file={},if=none", os),
+            "-device",
+            "virtio-blk-pci,drive=os,disable-legacy=on",
+            "-m",
+            "4G",
+            "-netdev",
+            &format!(
+                "tap,id=net0,ifname={},script=no,downscript=no",
+                net.tap_name
+            ),
+            "-device",
+            &format!("virtio-net-pci,netdev=net0,mac={}", net.guest_mac),
+        ]);
+
+        eprintln!("Spawning: {:?}", c);
+        let mut child = c.spawn().expect("Expect launching QEMU to succeed");
+
+        thread::sleep(std::time::Duration::from_secs(60));
+        let auth = windows_auth();
+        ssh_command_with_auth(&net.guest_ip, "shutdown /s", &auth)
+            .expect("Expect SSH command to work");
+
+        child.kill().unwrap();
+        child.wait().unwrap();
+
+        cleanup_tap(&net);
     }
 }

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -516,7 +516,7 @@ mod tests {
         cleanup_tap(&net);
     }
 
-    #[test]
+    // #[test]
     #[cfg(not(feature = "coreboot"))]
     fn test_boot_qemu_windows() {
         let fw = Firmware {
@@ -526,7 +526,7 @@ mod tests {
         test_boot_qemu_windows_common(&fw);
     }
 
-    #[test]
+    // #[test]
     #[cfg(feature = "coreboot")]
     fn test_boot_qemu_windows() {
         let fw = Firmware {
@@ -536,7 +536,7 @@ mod tests {
         test_boot_qemu_windows_common(&fw);
     }
 
-    #[test]
+    // #[test]
     #[cfg(not(feature = "coreboot"))]
     fn test_boot_ch_windows() {
         let tmp_dir = TempDir::new().expect("Expect creating temporary directory to succeed");

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -467,7 +467,7 @@ mod tests {
         }
     }
 
-    fn test_boot_qemu_windows_common<'a>(fw: &'a Firmware) {
+    fn test_boot_qemu_windows_common(fw: &Firmware) {
         let tmp_dir = TempDir::new().expect("Expect creating temporary directory to succeed");
         let net = GuestNetworkConfig::new(COUNTER.fetch_add(1, Ordering::SeqCst) as u8);
         let os = prepare_os_disk(&tmp_dir, WINDOWS_IMAGE_NAME);

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -467,19 +467,12 @@ mod tests {
         }
     }
 
-    #[test]
-    #[cfg(feature = "coreboot")]
-    fn test_boot_qemu_windows() {
+    fn test_boot_qemu_windows_common<'a>(fw: &'a Firmware) {
         let tmp_dir = TempDir::new().expect("Expect creating temporary directory to succeed");
         let net = GuestNetworkConfig::new(COUNTER.fetch_add(1, Ordering::SeqCst) as u8);
         let os = prepare_os_disk(&tmp_dir, WINDOWS_IMAGE_NAME);
 
         prepare_tap(&net);
-
-        let fw = Firmware {
-            fw_type: "-bios",
-            path: "resources/coreboot/coreboot/build/coreboot.rom",
-        };
 
         let mut c = Command::new("qemu-system-x86_64");
         c.args(&[
@@ -521,5 +514,25 @@ mod tests {
         child.wait().unwrap();
 
         cleanup_tap(&net);
+    }
+
+    #[test]
+    #[cfg(not(feature = "coreboot"))]
+    fn test_boot_qemu_windows() {
+        let fw = Firmware {
+            fw_type: "-kernel",
+            path: "target/target/release/hypervisor-fw",
+        };
+        test_boot_qemu_windows_common(&fw);
+    }
+
+    #[test]
+    #[cfg(feature = "coreboot")]
+    fn test_boot_qemu_windows() {
+        let fw = Firmware {
+            fw_type: "-bios",
+            path: "resources/coreboot/coreboot/build/coreboot.rom",
+        };
+        test_boot_qemu_windows_common(&fw);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #![feature(alloc_error_handler)]
-#![feature(global_asm)]
+#![feature(asm, global_asm)]
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(test, allow(unused_imports, dead_code))]
@@ -38,6 +38,7 @@ mod block;
 mod boot;
 mod bzimage;
 mod coreboot;
+mod delay;
 mod efi;
 mod fat;
 mod gdt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ mod part;
 mod pci;
 mod pe;
 mod pvh;
+mod rtc;
 mod virtio;
 
 #[cfg(all(not(test), feature = "log-panic"))]

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021 Akira Moroo
+
+use atomic_refcell::AtomicRefCell;
+use x86_64::instructions::port::{Port, PortWriteOnly};
+
+static RTC: AtomicRefCell<Rtc> = AtomicRefCell::new(Rtc::new());
+
+struct Rtc {
+    address_port: PortWriteOnly<u8>,
+    data_port: Port<u8>,
+}
+
+impl Rtc {
+    const fn new() -> Self {
+        Self {
+            address_port: PortWriteOnly::new(0x70),
+            data_port: Port::new(0x71),
+        }
+    }
+
+    fn read_cmos(&mut self, addr: u8) -> u8 {
+        assert!(addr < 128);
+        unsafe {
+            self.address_port.write(addr);
+            self.data_port.read()
+        }
+    }
+
+    fn is_updating(&mut self) -> bool {
+        self.read_cmos(0x0a) & 0x80 != 0
+    }
+
+    fn read(&mut self, offset: u8) -> Result<u8, ()> {
+        if crate::delay::wait_while(1, || self.is_updating()) {
+            return Err(());
+        }
+        Ok(self.read_cmos(offset))
+    }
+
+    fn read_date(&mut self) -> Result<(u8, u8, u8), ()> {
+        let mut year = self.read(0x09)?;
+        let mut month = self.read(0x08)?;
+        let mut day = self.read(0x07)?;
+
+        if (self.read_cmos(0x0b) & 0x04) != 0 {
+            year = bcd2dec(year);
+            month = bcd2dec(month);
+            day = bcd2dec(day);
+        }
+
+        Ok((year, month, day))
+    }
+
+    fn read_time(&mut self) -> Result<(u8, u8, u8), ()> {
+        let mut hour = self.read(0x04)?;
+        let mut minute = self.read(0x02)?;
+        let mut second = self.read(0x00)?;
+
+        if (self.read_cmos(0x0b) & 0x04) == 0 {
+            hour = bcd2dec(hour);
+            minute = bcd2dec(minute);
+            second = bcd2dec(second);
+        }
+
+        if (self.read_cmos(0x0b) & 0x02) == 0 && (hour & 0x80) != 0 {
+            hour = (hour & 0x7f) + 12 % 24;
+        }
+
+        Ok((hour, minute, second))
+    }
+}
+
+fn bcd2dec(b: u8) -> u8 {
+    ((b >> 4) & 0x0f) * 10 + (b & 0x0f)
+}
+
+pub fn read_date() -> Result<(u8, u8, u8), ()> {
+    RTC.borrow_mut().read_date()
+}
+
+pub fn read_time() -> Result<(u8, u8, u8), ()> {
+    RTC.borrow_mut().read_time()
+}


### PR DESCRIPTION
This PR proposes an experimental Windows boot support.
It is intended to replace the modified OVMF ROM image used by Cloud Hypervisor for Windows guests.

The commits are based on the findings during the debugging, and it somehow ad-hoc. There is room to be discussed.

The problem is that the Cloud Hypervisor is tested with the recent Windows Server version, but I don't have access to these OSes. Instead, I use the latest Windows10 (20H2) with virtio driver and EMS extension to debug the firmware. So I'm not sure these changes work with the target guests. Because the Cloud Hypervisor has integration tests with the private Windows Server VM image in the Jenkins CI server, I think it may also be possible to use it to test this firmware. If it can and OK, I would like to add integration tests for the Windows guests.