### PR TITLE
rtc: Fix BCD to decimal conversion checks

### DIFF
--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -9,6 +9,7 @@ static RTC: AtomicRefCell<Rtc> = AtomicRefCell::new(Rtc::new());
 struct Rtc {
     address_port: PortWriteOnly<u8>,
     data_port: Port<u8>,
+    reg_b: Option<u8>,
 }
 
 impl Rtc {
@@ -16,6 +17,7 @@ impl Rtc {
         Self {
             address_port: PortWriteOnly::new(0x70),
             data_port: Port::new(0x71),
+            reg_b: None,
         }
     }
 
@@ -38,12 +40,19 @@ impl Rtc {
         Ok(self.read_cmos(offset))
     }
 
+    fn get_reg_b(&mut self) -> u8 {
+        if self.reg_b.is_none() {
+            self.reg_b = Some(self.read_cmos(0x0b));
+        }
+        self.reg_b.unwrap()
+    }
+
     fn read_date(&mut self) -> Result<(u8, u8, u8), ()> {
         let mut year = self.read(0x09)?;
         let mut month = self.read(0x08)?;
         let mut day = self.read(0x07)?;
 
-        if (self.read_cmos(0x0b) & 0x04) == 0 {
+        if (self.get_reg_b() & 0x04) == 0 {
             year = bcd2dec(year);
             month = bcd2dec(month);
             day = bcd2dec(day);
@@ -57,13 +66,13 @@ impl Rtc {
         let mut minute = self.read(0x02)?;
         let mut second = self.read(0x00)?;
 
-        if (self.read_cmos(0x0b) & 0x04) == 0 {
+        if (self.get_reg_b() & 0x04) == 0 {
             hour = bcd2dec(hour);
             minute = bcd2dec(minute);
             second = bcd2dec(second);
         }
 
-        if ((self.read_cmos(0x0b) & 0x02) == 0) && ((hour & 0x80) != 0) {
+        if ((self.get_reg_b() & 0x02) == 0) && ((hour & 0x80) != 0) {
             hour = (hour & 0x7f) + 12 % 24;
         }
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -43,7 +43,7 @@ impl Rtc {
         let mut month = self.read(0x08)?;
         let mut day = self.read(0x07)?;
 
-        if (self.read_cmos(0x0b) & 0x04) != 0 {
+        if (self.read_cmos(0x0b) & 0x04) == 0 {
             year = bcd2dec(year);
             month = bcd2dec(month);
             day = bcd2dec(day);
@@ -63,7 +63,7 @@ impl Rtc {
             second = bcd2dec(second);
         }
 
-        if (self.read_cmos(0x0b) & 0x02) == 0 && (hour & 0x80) != 0 {
+        if ((self.read_cmos(0x0b) & 0x02) == 0) && ((hour & 0x80) != 0) {
             hour = (hour & 0x7f) + 12 % 24;
         }
 


### PR DESCRIPTION
c12cadd fixes RTC value format checks if it needs BCD to decimal conversion. This bug causes Windows 10 20H2 boot to fail on the bootmgfw.efi 1st stage bootloader. (Note that 2c9ca2f4621e0c2e0ddb467067828783524f2c72 still makes boot fail on runtime phase.)

8066695 is not to read RTC register B value every time.