### PR TITLE
efi: Improve Windows Guest Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ log-serial = []
 log-panic = ["log-serial"]
 integration_tests = []
 coreboot = []
+efi-var = []
 
 [dependencies]
 bitflags = "1.2.1"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,16 @@ pipeline {
                                                                 sh "nohup curl https://sh.rustup.rs -sSf | sh -s -- -y"
                                                         }
                                                 }
+                                                stage ('Download assets') {
+                                                        steps {
+                                                                sh "mkdir ./resources/images"
+                                                                azureDownload(storageCredentialId: 'ch-image-store',
+                                                                                          containerName: 'private-images',
+                                                                                          includeFilesPattern: 'windows-server-2019.raw',
+                                                                                          downloadType: 'container',
+                                                                                          downloadDirLoc: "./resources/images")
+                                                        }
+                                                }
                                                 stage('Run integration tests') {
                                                           steps {
                                                                   sh "./run_integration_tests.sh"
@@ -50,6 +60,16 @@ pipeline {
                                                 stage ('Install Rust') {
                                                         steps {
                                                                 sh "nohup curl https://sh.rustup.rs -sSf | sh -s -- -y"
+                                                        }
+                                                }
+                                                stage ('Download assets') {
+                                                        steps {
+                                                                sh "mkdir ./resources/images"
+                                                                azureDownload(storageCredentialId: 'ch-image-store',
+                                                                                          containerName: 'private-images',
+                                                                                          includeFilesPattern: 'windows-server-2019.raw',
+                                                                                          downloadType: 'container',
+                                                                                          downloadDirLoc: "./resources/images")
                                                         }
                                                 }
                                                 stage('Run integration tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,9 +24,14 @@ pipeline {
                                                                 sh "nohup curl https://sh.rustup.rs -sSf | sh -s -- -y"
                                                         }
                                                 }
+                                                stage('Run integration tests (Linux)') {
+                                                          steps {
+                                                                  sh "./run_integration_tests.sh linux"
+                                                          }
+                                                }
                                                 stage ('Download assets') {
                                                         steps {
-                                                                sh "mkdir ./resources/images"
+                                                                sh "mkdir -p ./resources/images"
                                                                 azureDownload(storageCredentialId: 'ch-image-store',
                                                                                           containerName: 'private-images',
                                                                                           includeFilesPattern: 'windows-server-2019.raw',
@@ -34,9 +39,9 @@ pipeline {
                                                                                           downloadDirLoc: "./resources/images")
                                                         }
                                                 }
-                                                stage('Run integration tests') {
+                                                stage('Run integration tests (Windows)') {
                                                           steps {
-                                                                  sh "./run_integration_tests.sh"
+                                                                  sh "./run_integration_tests.sh windows"
                                                           }
                                                 }
                                         }
@@ -62,9 +67,14 @@ pipeline {
                                                                 sh "nohup curl https://sh.rustup.rs -sSf | sh -s -- -y"
                                                         }
                                                 }
+                                                stage('Run integration tests (Linux)') {
+                                                          steps {
+                                                                  sh "./run_coreboot_integration_tests.sh linux"
+                                                          }
+                                                }
                                                 stage ('Download assets') {
                                                         steps {
-                                                                sh "mkdir ./resources/images"
+                                                                sh "mkdir -p ./resources/images"
                                                                 azureDownload(storageCredentialId: 'ch-image-store',
                                                                                           containerName: 'private-images',
                                                                                           includeFilesPattern: 'windows-server-2019.raw',
@@ -72,9 +82,9 @@ pipeline {
                                                                                           downloadDirLoc: "./resources/images")
                                                         }
                                                 }
-                                                stage('Run integration tests') {
+                                                stage('Run integration tests (Windows)') {
                                                           steps {
-                                                                  sh "./run_coreboot_integration_tests.sh"
+                                                                  sh "./run_coreboot_integration_tests.sh windows"
                                                           }
                                                 }
                                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
         stages {
                 stage ('Build') {
                         parallel {
-                                stage ('CH/QEMU Tests') {
+                                stage ('Linux CH/QEMU Tests') {
                                         agent { node { label 'focal-fw' } }
                                         options {
                                                 timeout(time: 1, unit: 'HOURS')
@@ -29,24 +29,9 @@ pipeline {
                                                                   sh "./run_integration_tests.sh linux"
                                                           }
                                                 }
-                                                stage ('Download assets') {
-                                                        steps {
-                                                                sh "mkdir -p ./resources/images"
-                                                                azureDownload(storageCredentialId: 'ch-image-store',
-                                                                                          containerName: 'private-images',
-                                                                                          includeFilesPattern: 'windows-server-2019.raw',
-                                                                                          downloadType: 'container',
-                                                                                          downloadDirLoc: "./resources/images")
-                                                        }
-                                                }
-                                                stage('Run integration tests (Windows)') {
-                                                          steps {
-                                                                  sh "./run_integration_tests.sh windows"
-                                                          }
-                                                }
                                         }
                                 }
-                                stage ('coreboot QEMU Tests') {
+                                stage ('Linux coreboot QEMU Tests') {
                                         agent { node { label 'focal-fw' } }
                                         options {
                                                 timeout(time: 1, unit: 'HOURS')
@@ -67,10 +52,33 @@ pipeline {
                                                                 sh "nohup curl https://sh.rustup.rs -sSf | sh -s -- -y"
                                                         }
                                                 }
-                                                stage('Run integration tests (Linux)') {
+                                                stage('Run integration tests') {
                                                           steps {
                                                                   sh "./run_coreboot_integration_tests.sh linux"
                                                           }
+                                                }
+                                        }
+                                }
+                                stage ('Windows CH Tests') {
+                                        agent { node { label 'focal-fw' } }
+                                        options {
+                                                timeout(time: 1, unit: 'HOURS')
+                                        }
+                                        stages {
+                                                stage ('Checkout') {
+                                                        steps {
+                                                                checkout scm
+                                                        }
+                                                }
+                                                stage ('Install system packages') {
+                                                        steps {
+                                                                sh "sudo apt-get -y install build-essential mtools qemu-system-x86 libssl-dev pkg-config"
+                                                        }
+                                                }
+                                                stage ('Install Rust') {
+                                                        steps {
+                                                                sh "nohup curl https://sh.rustup.rs -sSf | sh -s -- -y"
+                                                        }
                                                 }
                                                 stage ('Download assets') {
                                                         steps {
@@ -82,9 +90,9 @@ pipeline {
                                                                                           downloadDirLoc: "./resources/images")
                                                         }
                                                 }
-                                                stage('Run integration tests (Windows)') {
+                                                stage('Run integration tests') {
                                                           steps {
-                                                                  sh "./run_coreboot_integration_tests.sh windows"
+                                                                  sh "./run_integration_tests.sh windows"
                                                           }
                                                 }
                                         }

--- a/run_coreboot_integration_tests.sh
+++ b/run_coreboot_integration_tests.sh
@@ -25,7 +25,9 @@ make -C $CB_PATH crossgcc-i386 CPUS="$(nproc)"
 make -C $CB_PATH olddefconfig
 make -C $CB_PATH -j"$(nproc)"
 
-bash ./fetch_disk_images.sh
+if [ "$TARGET" == "linux" ]; then
+  bash ./fetch_disk_images.sh
+fi
 
 # Add the user to the kvm group (if not already in it), so they can run VMs
 id -nGz "$USER" | grep -qzxF kvm || sudo adduser "$USER" kvm

--- a/run_coreboot_integration_tests.sh
+++ b/run_coreboot_integration_tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -xeuf
 
+TARGET="${1:-linux}"
+
 source "${CARGO_HOME:-$HOME/.cargo}/env"
 
 rustup component add rust-src
@@ -30,5 +32,5 @@ id -nGz "$USER" | grep -qzxF kvm || sudo adduser "$USER" kvm
 
 newgrp kvm << EOF
 export RUST_BACKTRACE=1
-cargo test --features "coreboot integration_tests"  -- test_boot
+cargo test --features "coreboot integration_tests" "integration::tests::${TARGET}"
 EOF

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -17,7 +17,9 @@ if [ ! -f "$CH_PATH" ]; then
     sudo setcap cap_net_admin+ep $CH_PATH
 fi
 
-bash ./fetch_disk_images.sh
+if [ "$TARGET" == "linux" ]; then
+  bash ./fetch_disk_images.sh
+fi
 
 # Add the user to the kvm group (if not already in it), so they can run VMs
 id -nGz "$USER" | grep -qzxF kvm || sudo adduser "$USER" kvm

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -xeuf
 
+TARGET="${1:-linux}"
+
 source "${CARGO_HOME:-$HOME/.cargo}/env"
 
 rustup component add rust-src
@@ -22,5 +24,5 @@ id -nGz "$USER" | grep -qzxF kvm || sudo adduser "$USER" kvm
 
 newgrp kvm << EOF
 export RUST_BACKTRACE=1
-cargo test --features "integration_tests"  -- test_boot
+cargo test --features "integration_tests" "integration::tests::${TARGET}"
 EOF

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -291,9 +291,13 @@ pub extern "win64" fn get_variable(
     data_size: *mut usize,
     data: *mut c_void,
 ) -> Status {
-    VARIABLES
-        .borrow_mut()
-        .get(variable_name, vendor_guid, attributes, data_size, data)
+    if cfg!(feature = "efi-var") {
+        VARIABLES
+            .borrow_mut()
+            .get(variable_name, vendor_guid, attributes, data_size, data)
+    } else {
+        Status::NOT_FOUND
+    }
 }
 
 pub extern "win64" fn get_next_variable_name(
@@ -311,9 +315,13 @@ pub extern "win64" fn set_variable(
     data_size: usize,
     data: *mut c_void,
 ) -> Status {
-    VARIABLES
-        .borrow_mut()
-        .set(variable_name, vendor_guid, attributes, data_size, data)
+    if cfg!(feature = "efi-var") {
+        VARIABLES
+            .borrow_mut()
+            .set(variable_name, vendor_guid, attributes, data_size, data)
+    } else {
+        Status::UNSUPPORTED
+    }
 }
 
 pub extern "win64" fn get_next_high_mono_count(_: *mut u32) -> Status {

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -597,6 +597,7 @@ mod tests {
         }
 
         #[test]
+        #[ignore] // Windows guest test on QEMU is not supported yet.
         #[cfg(not(feature = "coreboot"))]
         fn test_boot_qemu_windows() {
             let fw = Firmware {
@@ -607,6 +608,7 @@ mod tests {
         }
 
         #[test]
+        #[ignore] // Windows guest test on QEMU is not supported yet.
         #[cfg(feature = "coreboot")]
         fn test_boot_qemu_windows() {
             let fw = Firmware {

--- a/target.json
+++ b/target.json
@@ -14,7 +14,7 @@
   "features": "-mmx,-sse,+soft-float",
   "dynamic-linking-available": false,
   "code-model": "small",
-  "relocation-model": "static",
+  "relocation-model": "pic",
   "pre-link-args": {
     "ld.lld": ["--script=layout.ld"]
   }


### PR DESCRIPTION
The changes in this PR are to support Windows guests. I previously added EFI variable feature to support stock Ubuntu images, but it seems to be needed to boot Linux and blocks Windows boot. So let's opt out the feature.