### PR TITLE
build: Bump r-efi from 3.2.0 to 4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,9 +189,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "r-efi"
-version = "3.2.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6198999a900fd9cf051f2109ec3b9589b5c67cbfc77ff82c9fdff24aec83aa7b"
+checksum = "6c4257a6ffb364d7f938c0311733a793327639b3d34c0b4af0b3bb775ef3e1b8"
 
 [[package]]
 name = "rand"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ efi-var = []
 bitflags = "1.2.1"
 x86_64 = "0.14.3"
 atomic_refcell = "0.1.7"
-r-efi = "3.2.0"
+r-efi = "4.0.0"
 uart_16550 = "0.2.15"
 linked_list_allocator = "0.9.0"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,9 @@ pipeline {
                                 }
                                 stage ('Windows CH Tests') {
                                         agent { node { label 'focal-fw' } }
+                                        environment {
+                                                AZURE_CONNECTION_STRING = credentials('46b4e7d6-315f-4cc1-8333-b58780863b9b')
+                                        }
                                         options {
                                                 timeout(time: 1, unit: 'HOURS')
                                         }
@@ -72,7 +75,7 @@ pipeline {
                                                 }
                                                 stage ('Install system packages') {
                                                         steps {
-                                                                sh "sudo apt-get -y install build-essential mtools qemu-system-x86 libssl-dev pkg-config"
+                                                                sh "sudo apt-get -y install build-essential mtools qemu-system-x86 libssl-dev pkg-config azure-cli"
                                                         }
                                                 }
                                                 stage ('Install Rust') {
@@ -83,11 +86,7 @@ pipeline {
                                                 stage ('Download assets') {
                                                         steps {
                                                                 sh "mkdir -p ./resources/images"
-                                                                azureDownload(storageCredentialId: 'ch-image-store',
-                                                                                          containerName: 'private-images',
-                                                                                          includeFilesPattern: 'windows-server-2019.raw',
-                                                                                          downloadType: 'container',
-                                                                                          downloadDirLoc: "./resources/images")
+                                                                sh 'az storage blob download --container-name private-images --file "./resources/images/windows-server-2019.raw" --name windows-server-2019.raw --connection-string "$AZURE_CONNECTION_STRING"'
                                                         }
                                                 }
                                                 stage('Run integration tests') {

--- a/src/efi/block.rs
+++ b/src/efi/block.rs
@@ -15,7 +15,7 @@
 use core::ffi::c_void;
 
 use r_efi::{
-    efi::{AllocateType, Guid, MemoryType, Status},
+    efi::{self, Guid, Status},
     eficall, eficall_abi,
     protocols::device_path::Protocol as DevicePathProtocol,
 };
@@ -187,8 +187,8 @@ impl<'a> BlockWrapper<'a> {
 
         let size = core::mem::size_of::<BlockWrapper>();
         let (_status, new_address) = super::ALLOCATOR.borrow_mut().allocate_pages(
-            AllocateType::AllocateAnyPages,
-            MemoryType::LoaderData,
+            efi::ALLOCATE_ANY_PAGES,
+            efi::LOADER_DATA,
             ((size + super::PAGE_SIZE as usize - 1) / super::PAGE_SIZE as usize) as u64,
             0_u64,
         );

--- a/src/efi/file.rs
+++ b/src/efi/file.rs
@@ -15,7 +15,7 @@
 use core::ffi::c_void;
 
 use r_efi::{
-    efi::{AllocateType, Char16, Guid, MemoryType, Status},
+    efi::{self, Char16, Guid, Status},
     protocols::{
         device_path::Protocol as DevicePathProtocol, file::Protocol as FileProtocol,
         simple_file_system::Protocol as SimpleFileSystemProtocol,
@@ -270,8 +270,8 @@ impl<'a> FileSystemWrapper<'a> {
     fn create_file(&self, node: crate::fat::Node<'a>) -> Option<*mut FileWrapper> {
         let size = core::mem::size_of::<FileWrapper>();
         let (status, new_address) = super::ALLOCATOR.borrow_mut().allocate_pages(
-            AllocateType::AllocateAnyPages,
-            MemoryType::LoaderData,
+            efi::ALLOCATE_ANY_PAGES,
+            efi::LOADER_DATA,
             ((size + super::PAGE_SIZE as usize - 1) / super::PAGE_SIZE as usize) as u64,
             0_u64,
         );

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -536,10 +536,20 @@ mod tests {
             }
         }
 
+        fn prepare_windows_os_disk(_: &TempDir, image_name: &str) -> String {
+            let src_osdisk = std::env::current_dir()
+                .unwrap()
+                .join("resources")
+                .join("images")
+                .join(image_name);
+            let dest_osdisk = src_osdisk;
+            dest_osdisk.to_str().unwrap().to_owned()
+        }
+
         fn test_boot_qemu_windows_common(fw: &Firmware) {
             let tmp_dir = TempDir::new().expect("Expect creating temporary directory to succeed");
             let net = GuestNetworkConfig::new(COUNTER.fetch_add(1, Ordering::SeqCst) as u8);
-            let os = prepare_os_disk(&tmp_dir, WINDOWS_IMAGE_NAME);
+            let os = prepare_windows_os_disk(&tmp_dir, WINDOWS_IMAGE_NAME);
 
             prepare_tap(&net);
 
@@ -622,7 +632,7 @@ mod tests {
         #[cfg(not(feature = "coreboot"))]
         fn test_boot_ch_windows() {
             let tmp_dir = TempDir::new().expect("Expect creating temporary directory to succeed");
-            let os = prepare_os_disk(&tmp_dir, WINDOWS_IMAGE_NAME);
+            let os = prepare_windows_os_disk(&tmp_dir, WINDOWS_IMAGE_NAME);
 
             let mut c = Command::new("./resources/cloud-hypervisor");
             c.args(&[


### PR DESCRIPTION
All enums are converted to constants from 4.0.0. This commit is to follow
this backward compatibility breaking change.

Signed-off-by: Akira Moroo <retrage01@gmail.com>