### PR TITLE
pci: Probe sixth BAR as well

### DIFF
--- a/src/pci.rs
+++ b/src/pci.rs
@@ -178,7 +178,7 @@ impl PciDevice {
         let mut current_bar = 0;
 
         //0x24 offset is last bar
-        while current_bar_offset < 0x24 {
+        while current_bar_offset <= 0x24 {
             #[allow(clippy::blacklisted_name)]
             let bar = self.read_u32(current_bar_offset);
 


### PR DESCRIPTION
Current implementation only probes to the fifth BAR (0x20).

FWIW this PR allows to probe the sixth BAR.