### PR TITLE
asm: Add att_syntax and raw options

### DIFF
--- a/src/asm/mod.rs
+++ b/src/asm/mod.rs
@@ -1,1 +1,1 @@
-global_asm!(include_str!("ram32.s"));
+global_asm!(include_str!("ram32.s"), options(att_syntax, raw));


### PR DESCRIPTION
As reported in issue #143, recent nightly rustc fails to compile the
assembly file because it uses AT&T syntax. It is also suggested that use
raw option when using `include_str!` macro.

https://rust-lang.github.io/rfcs/2873-inline-asm.html#options-1
https://github.com/rust-lang/rust/pull/86599

Signed-off-by: Akira Moroo <retrage01@gmail.com>