### PR TITLE
Remove redundant constructor call in main function

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -179,7 +179,6 @@ fn main(info: &dyn boot::Info) -> ! {
         VIRTIO_PCI_BLOCK_DEVICE_ID,
         |pci_device| {
             let mut pci_transport = pci::VirtioPciTransport::new(pci_device);
-            block::VirtioBlockDevice::new(&mut pci_transport);
             let mut device = block::VirtioBlockDevice::new(&mut pci_transport);
             boot_from_device(&mut device, info)
         },


### PR DESCRIPTION
main: Remove redundant constructor call in main function

In the `main` function in `main.rs`, there was an unintended call to the
constructor of `VirtioBlockDevice` following the definition of
`pci_transport`. This PR removes that unused call.

Signed-off-by: henryksloan@gmail.com