### PR TITLE
fat: Fix incomplete comparing in compare_name and compare_short_name

### DIFF
--- a/src/fat.rs
+++ b/src/fat.rs
@@ -531,11 +531,18 @@ fn compare_short_name(name: &str, de: &DirectoryEntry) -> bool {
 
         i += 1;
     }
+    while i < 11 {
+        if de.name[i] != b' ' {
+            return false;
+        }
+        i += 1;
+    }
     true
 }
 
 fn compare_name(name: &str, de: &DirectoryEntry) -> bool {
-    compare_short_name(name, de) || &de.long_name[0..name.len()] == name.as_bytes()
+    compare_short_name(name, de)
+        || (&de.long_name[0..name.len()] == name.as_bytes() && de.long_name[name.len()] == 0)
 }
 
 impl<'a> Filesystem<'a> {
@@ -1067,6 +1074,8 @@ mod tests {
         assert!(super::compare_short_name("X.abc", &de));
         de.name.copy_from_slice(b"ABCDEFGHIJK");
         assert!(super::compare_short_name("abcdefgh.ijk", &de));
+        de.name.copy_from_slice(b"EFI-SYSTEM ");
+        assert!(!super::compare_short_name("EFI", &de));
     }
 
     #[test]

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -43,6 +43,8 @@ impl From<bzimage::Error> for Error {
     }
 }
 
+const ENTRY_EXTENSION: &str = ".conf";
+
 fn default_entry_file(f: &mut fat::File) -> Result<[u8; 260], fat::Error> {
     let mut data = [0; 4096];
     assert!(f.get_size() as usize <= data.len());
@@ -64,6 +66,8 @@ fn default_entry_file(f: &mut fat::File) -> Result<[u8; 260], fat::Error> {
         if let Some(entry) = line.strip_prefix("default") {
             let entry = entry.trim();
             entry_file_name[0..entry.len()].copy_from_slice(entry.as_bytes());
+            entry_file_name[entry.len()..entry.len() + ENTRY_EXTENSION.len()]
+                .copy_from_slice(ENTRY_EXTENSION.as_bytes());
         }
     }
 
@@ -170,7 +174,7 @@ mod tests {
         let mut f: crate::fat::File = fs.open("/loader/loader.conf").unwrap().try_into().unwrap();
         let s = super::default_entry_file(&mut f).unwrap();
         let s = super::ascii_strip(&s);
-        assert_eq!(s, "Clear-linux-kvm-5.0.6-318");
+        assert_eq!(s, "Clear-linux-kvm-5.0.6-318.conf");
 
         let default_entry_path = super::default_entry_path(&fs).unwrap();
         let default_entry_path = super::ascii_strip(&default_entry_path);


### PR DESCRIPTION
compare_name function and compare_short_name function compare incompletely if the argument "name" is shorter than a name of directory entries.
This causes a failure to load EFI as reported in #164

Signed-off-by: Yuji Hagiwara <yuuzi41@gmail.com>