### PR TITLE
tests: Replace Ubuntu Hirsute with Jammy

### DIFF
--- a/scripts/fetch_disk_images.sh
+++ b/scripts/fetch_disk_images.sh
@@ -42,12 +42,12 @@ fetch_disk_images() {
     fetch_image "$FOCAL_OS_IMAGE_NAME" "$FOCAL_OS_IMAGE_URL"
     convert_image "$FOCAL_OS_IMAGE_NAME" "$FOCAL_OS_RAW_IMAGE_NAME"
 
-    HIRSUTE_OS_IMAGE_NAME="hirsute-server-cloudimg-amd64.img"
-    HIRSUTE_OS_RAW_IMAGE_NAME="hirsute-server-cloudimg-amd64-raw.img"
-    HIRSUTE_OS_IMAGE_BASE="https://cloud-images.ubuntu.com/hirsute/current"
-    HIRSUTE_OS_IMAGE_URL="$HIRSUTE_OS_IMAGE_BASE/$HIRSUTE_OS_IMAGE_NAME"
-    fetch_image "$HIRSUTE_OS_IMAGE_NAME" "$HIRSUTE_OS_IMAGE_URL"
-    convert_image "$HIRSUTE_OS_IMAGE_NAME" "$HIRSUTE_OS_RAW_IMAGE_NAME"
+    JAMMY_OS_IMAGE_NAME="jammy-server-cloudimg-amd64.img"
+    JAMMY_OS_RAW_IMAGE_NAME="jammy-server-cloudimg-amd64-raw.img"
+    JAMMY_OS_IMAGE_BASE="https://cloud-images.ubuntu.com/jammy/current"
+    JAMMY_OS_IMAGE_URL="$JAMMY_OS_IMAGE_BASE/$JAMMY_OS_IMAGE_NAME"
+    fetch_image "$JAMMY_OS_IMAGE_NAME" "$JAMMY_OS_IMAGE_URL"
+    convert_image "$JAMMY_OS_IMAGE_NAME" "$JAMMY_OS_RAW_IMAGE_NAME"
 
     popd
 }

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -616,7 +616,7 @@ mod tests {
 
         const BIONIC_IMAGE_NAME: &str = "bionic-server-cloudimg-amd64-raw.img";
         const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-amd64-raw.img";
-        const HIRSUTE_IMAGE_NAME: &str = "hirsute-server-cloudimg-amd64-raw.img";
+        const JAMMY_IMAGE_NAME: &str = "jammy-server-cloudimg-amd64-raw.img";
         const CLEAR_IMAGE_NAME: &str = "clear-31311-cloudguest.img";
 
         #[test]
@@ -630,8 +630,8 @@ mod tests {
         }
 
         #[test]
-        fn test_boot_qemu_hirsute() {
-            test_boot(HIRSUTE_IMAGE_NAME, &UbuntuCloudInit {}, spawn_qemu)
+        fn test_boot_qemu_jammy() {
+            test_boot(JAMMY_IMAGE_NAME, &UbuntuCloudInit {}, spawn_qemu)
         }
 
         #[test]
@@ -653,8 +653,8 @@ mod tests {
 
         #[test]
         #[cfg(not(feature = "coreboot"))]
-        fn test_boot_ch_hirsute() {
-            test_boot(HIRSUTE_IMAGE_NAME, &UbuntuCloudInit {}, spawn_ch)
+        fn test_boot_ch_jammy() {
+            test_boot(JAMMY_IMAGE_NAME, &UbuntuCloudInit {}, spawn_ch)
         }
 
         #[test]


### PR DESCRIPTION
Ubuntu 21.04 Hirsute Hippo reached the EOL on January 20, 2022. This
commit updates to Ubuntu 22.04 Jammy Jellyfish.

Fixes #168 CI error.

Signed-off-by: Akira Moroo <retrage01@gmail.com>