### PR TITLE
build: Update toolchain to nightly-2022-06-10

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - nightly-2022-03-28
+          - nightly-2022-06-10
         target:
           - x86_64-unknown-linux-gnu
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - nightly-2022-03-28
+          - nightly-2022-06-10
         target:
           - x86_64-unknown-linux-gnu
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hypervisor-fw"
 version = "0.4.0"
 authors = ["Rob Bradford <robert.bradford@intel.com>"]
-edition = "2018"
+edition = "2021"
 
 # Despite "panic-strategy": "abort" being set in target.json, panic = "abort" is
 # needed here to make "cargo check" and "cargo clippy" run without errors.

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04 as dev
 
 ARG TARGETARCH
-ARG RUST_TOOLCHAIN="nightly-2022-03-28"
+ARG RUST_TOOLCHAIN="nightly-2022-06-10"
 ARG RHF_SRC_DIR="/rust-hypervisor-firmware"
 ARG RHF_BUILD_DIR="$RHF_SRC_DIR/build"
 ARG CARGO_REGISTRY_DIR="$RHF_BUILD_DIR/cargo_registry"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-03-28"
+channel = "nightly-2022-06-10"
 components = ["rust-src", "clippy", "rustfmt"]
 targets = ["x86_64-unknown-linux-gnu"]
 profile = "default"

--- a/src/block.rs
+++ b/src/block.rs
@@ -75,7 +75,7 @@ struct DriverState {
     next_head: usize,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     BlockIOError,
 
@@ -109,7 +109,7 @@ pub trait SectorWrite {
     fn flush(&self) -> Result<(), Error>;
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Eq, Copy, Clone)]
 enum RequestType {
     Read = 0,
     Write = 1,

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -31,6 +31,7 @@ use r_efi::{
     protocols::{
         device_path::Protocol as DevicePathProtocol, loaded_image::Protocol as LoadedImageProtocol,
     },
+    system::{ConfigurationTable, RuntimeServices},
 };
 
 use crate::boot;
@@ -209,11 +210,11 @@ unsafe fn fixup_at_virtual(descriptors: &[alloc::MemoryDescriptor]) {
 
     let ct = st.configuration_table;
     let ptr = convert_internal_pointer(descriptors, (ct as *const _) as u64).unwrap();
-    st.configuration_table = transmute(ptr);
+    st.configuration_table = ptr as *mut ConfigurationTable;
 
     let rs = st.runtime_services;
     let ptr = convert_internal_pointer(descriptors, (rs as *const _) as u64).unwrap();
-    st.runtime_services = transmute(ptr);
+    st.runtime_services = ptr as *mut RuntimeServices;
 }
 
 pub extern "win64" fn not_available() -> Status {

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -45,7 +45,7 @@ mod var;
 use alloc::Allocator;
 use var::VariableAllocator;
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 enum HandleType {
     None,
     Block,

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -85,7 +85,7 @@ pub struct DirectoryEntry {
     cluster: u32,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 enum FatType {
     Unknown,
     FAT12,
@@ -113,7 +113,7 @@ pub struct Filesystem<'a> {
     root_cluster: u32, // FAT32 only
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     Block(BlockError),
     Unsupported,
@@ -122,7 +122,7 @@ pub enum Error {
     InvalidOffset,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 enum FileType {
     File,
     Directory,

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -73,7 +73,7 @@ impl Rtc {
         }
 
         if ((self.get_reg_b() & 0x02) == 0) && ((hour & 0x80) != 0) {
-            hour = (hour & 0x7f) + 12 % 24;
+            hour = ((hour & 0x7f) + 12) % 24;
         }
 
         Ok((hour, minute, second))

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -35,7 +35,7 @@ macro_rules! log {
     ($($arg:tt)*) => {{
         use core::fmt::Write;
         #[cfg(all(feature = "log-serial", not(test)))]
-        writeln!(crate::serial::Serial, $($arg)*).unwrap();
+        writeln!($crate::serial::Serial, $($arg)*).unwrap();
         #[cfg(all(feature = "log-serial", test))]
         println!($($arg)*);
     }};


### PR DESCRIPTION
This PR proposes updating the Rust toolchain to nightly-2022-06-10. It also fixes some issues newly reported by clippy.