### PR TITLE
tests: Correctly determine cargo home directory in test scripts

### DIFF
--- a/scripts/run_cargo_tests.sh
+++ b/scripts/run_cargo_tests.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-source $HOME/.cargo/env
+source "${CARGO_HOME:-$HOME/.cargo}/env"
 
 export RUSTFLAGS="-D warnings"
 

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $HOME/.cargo/env
+source "${CARGO_HOME:-$HOME/.cargo}/env"
 source $(dirname "$0")/make-test-disks.sh
 
 WORKLOADS_DIR="$HOME/workloads"


### PR DESCRIPTION
Small change to correctly `source` cargo environment variables on installations
that have `CARGO_HOME` in a non-default location.
