### PR TITLE
build: Bump linked_list_allocator from 0.9.1 to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549ce1740e46b291953c4340adcd74c59bcf4308f4cac050fd33ba91b7168f4a"
+checksum = "222d00bf23b303e0c82c7a4d5f04dc90f33a58b26a3adb1a09c6fbcf56cbd2a9"
 dependencies = [
  "spinning_top",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ x86_64 = "0.14.9"
 atomic_refcell = "0.1.8"
 r-efi = "4.0.0"
 uart_16550 = "0.2.18"
-linked_list_allocator = "0.9.1"
+linked_list_allocator = "0.10.0"
 
 [dev-dependencies]
 dirs = "4.0.0"

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -950,7 +950,7 @@ fn init_heap_allocator(size: usize) {
     );
     assert!(status == Status::SUCCESS);
     unsafe {
-        HEAP_ALLOCATOR.lock().init(heap_start as usize, size);
+        HEAP_ALLOCATOR.lock().init(heap_start as *mut _, size);
     }
 }
 


### PR DESCRIPTION
This commit also fixes a build error.

Signed-off-by: Akira Moroo <retrage01@gmail.com>