### PR TITLE
Handle `default` bootloader entry patterns correctly

### DIFF
--- a/src/fat.rs
+++ b/src/fat.rs
@@ -86,6 +86,16 @@ pub struct DirectoryEntry {
     cluster: u32,
 }
 
+impl DirectoryEntry {
+    pub fn long_name(&self) -> [u8; 255] {
+        self.long_name
+    }
+
+    pub fn is_file(&self) -> bool {
+        matches!(self.file_type, FileType::File)
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum FatType {
     Unknown,
@@ -121,6 +131,7 @@ pub enum Error {
     NotFound,
     EndOfFile,
     InvalidOffset,
+    NodeTypeMismatch,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -147,23 +158,23 @@ impl<'a> From<Directory<'a>> for Node<'a> {
 }
 
 impl<'a> TryFrom<Node<'a>> for File<'a> {
-    type Error = ();
+    type Error = Error;
 
     fn try_from(from: Node<'a>) -> Result<Self, Self::Error> {
         match from {
             Node::File(f) => Ok(f),
-            _ => Err(()),
+            _ => Err(Self::Error::NodeTypeMismatch),
         }
     }
 }
 
 impl<'a> TryFrom<Node<'a>> for Directory<'a> {
-    type Error = ();
+    type Error = Error;
 
     fn try_from(from: Node<'a>) -> Result<Self, Self::Error> {
         match from {
             Node::Directory(d) => Ok(d),
-            _ => Err(()),
+            _ => Err(Self::Error::NodeTypeMismatch),
         }
     }
 }

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::convert::TryFrom;
-
 use crate::{
     block::{Error as BlockError, SectorRead},
     mem::MemoryRegion,
 };
+use core::convert::TryFrom;
 
 #[repr(packed)]
 struct Header {
@@ -878,11 +877,10 @@ impl<'a> Filesystem<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryInto;
-    use std::path::PathBuf;
-
     use super::Read;
     use crate::part::tests::*;
+    use std::convert::TryInto;
+    use std::path::PathBuf;
 
     fn fat_test_image_paths() -> Vec<PathBuf> {
         let images = ["fat12.img", "fat16.img", "fat32.img"];

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::convert::TryFrom;
+
 use crate::{
     block::{Error as BlockError, SectorRead},
     mem::MemoryRegion,
 };
-use core::convert::TryFrom;
 
 #[repr(packed)]
 struct Header {
@@ -311,7 +312,8 @@ impl<'a> Directory<'a> {
         Ok(true)
     }
 
-    // Returns and then increments to point to the next one, may return EndOfFile if this is the last entry
+    // Returns and then increments to point to the next one, may return EndOfFile if
+    // this is the last entry
     pub fn next_entry(&mut self) -> Result<DirectoryEntry, Error> {
         let mut long_entry = [0u16; 260];
         loop {
@@ -501,7 +503,8 @@ impl<'a> Read for File<'a> {
             self.active_cluster = self.start_cluster;
         }
 
-        // Like read but without reading, follow cluster chain if we reach end of cluster
+        // Like read but without reading, follow cluster chain if we reach end of
+        // cluster
         while self.position != position {
             if self.sector_offset == u64::from(self.filesystem.sectors_per_cluster) {
                 match self.filesystem.next_cluster(self.active_cluster) {
@@ -536,8 +539,9 @@ impl<'a> SectorRead for Filesystem<'a> {
     }
 }
 
-// Do a case-insensitive match on the name with the 8.3 format that you get from FAT.
-// In the FAT directory entry the "." isn't stored and any gaps are padded with " ".
+// Do a case-insensitive match on the name with the 8.3 format that you get from
+// FAT. In the FAT directory entry the "." isn't stored and any gaps are padded
+// with " ".
 fn compare_short_name(name: &str, de: &DirectoryEntry) -> bool {
     let name = name.trim_matches(char::from(0));
     // 8.3 (plus 1 for the separator)
@@ -863,10 +867,11 @@ impl<'a> Filesystem<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::Read;
-    use crate::part::tests::*;
     use std::convert::TryInto;
     use std::path::PathBuf;
+
+    use super::Read;
+    use crate::part::tests::*;
 
     fn fat_test_image_paths() -> Vec<PathBuf> {
         let images = ["fat12.img", "fat16.img", "fat32.img"];

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -19,6 +19,8 @@ use crate::{
     fat::{self, Read},
 };
 
+const ENTRY_DIRECTORY: &str = "/loader/entries";
+
 pub struct LoaderConfig {
     pub bzimage_path: [u8; 260],
     pub initrd_path: [u8; 260],
@@ -27,29 +29,29 @@ pub struct LoaderConfig {
 
 #[derive(Debug)]
 pub enum Error {
-    FileError(fat::Error),
-    BzImageError(bzimage::Error),
+    File(fat::Error),
+    BzImage(bzimage::Error),
+    UnterminatedString,
 }
 
 impl From<fat::Error> for Error {
     fn from(e: fat::Error) -> Error {
-        Error::FileError(e)
+        Error::File(e)
     }
 }
 
 impl From<bzimage::Error> for Error {
     fn from(e: bzimage::Error) -> Error {
-        Error::BzImageError(e)
+        Error::BzImage(e)
     }
 }
 
-const ENTRY_EXTENSION: &str = ".conf";
-
-fn default_entry_file(f: &mut fat::File) -> Result<[u8; 260], fat::Error> {
+/// Given a `loader.conf` file, find the `default` option value.
+fn default_entry_pattern(f: &mut fat::File) -> Result<[u8; 260], fat::Error> {
     let mut data = [0; 4096];
     assert!(f.get_size() as usize <= data.len());
 
-    let mut entry_file_name = [0; 260];
+    let mut entry_pattern = [0; 260];
     let mut offset = 0;
     loop {
         match f.read(&mut data[offset..offset + 512]) {
@@ -63,15 +65,99 @@ fn default_entry_file(f: &mut fat::File) -> Result<[u8; 260], fat::Error> {
 
     let conf = unsafe { core::str::from_utf8_unchecked(&data) };
     for line in conf.lines() {
-        if let Some(entry) = line.strip_prefix("default") {
-            let entry = entry.trim();
-            entry_file_name[0..entry.len()].copy_from_slice(entry.as_bytes());
-            entry_file_name[entry.len()..entry.len() + ENTRY_EXTENSION.len()]
-                .copy_from_slice(ENTRY_EXTENSION.as_bytes());
+        if let Some(mut pattern) = line.strip_prefix("default") {
+            pattern = pattern.trim();
+            entry_pattern[0..pattern.len()].copy_from_slice(pattern.as_bytes());
         }
     }
 
-    Ok(entry_file_name)
+    Ok(entry_pattern)
+}
+
+/// Given a glob-like pattern, select a boot entry from `/loader/entries/`,
+/// falling back to the first entry encountered if no match is found.
+fn find_entry(fs: &fat::Filesystem, pattern: &[u8]) -> Result<[u8; 255], Error> {
+    let mut dir: fat::Directory = fs.open(ENTRY_DIRECTORY)?.try_into()?;
+    let mut fallback = None;
+    loop {
+        match dir.next_entry() {
+            Ok(de) => {
+                if !de.is_file() {
+                    continue;
+                }
+                let file_name = de.long_name();
+                // return the first matching file name
+                if compare_entry(&file_name, pattern)? {
+                    return Ok(file_name);
+                }
+                // only fallback to entry files ending with `.conf`
+                if fallback.is_none() && compare_entry(&file_name, b"*.conf\0")? {
+                    fallback = Some(file_name);
+                }
+            }
+            Err(fat::Error::EndOfFile) => break,
+            Err(err) => return Err(err.into()),
+        }
+    }
+    fallback.ok_or_else(|| fat::Error::NotFound.into())
+}
+
+/// Attempt to match a file name with a glob-like pattern.
+/// An error is returned if either `file_name` or `pattern` are not `\0`
+/// terminated.
+fn compare_entry(file_name: &[u8], pattern: &[u8]) -> Result<bool, Error> {
+    fn compare_entry_inner<I>(
+        mut name_iter: core::iter::Peekable<I>,
+        mut pattern: &[u8],
+        max_depth: usize,
+    ) -> Result<bool, Error>
+    where
+        I: Iterator<Item = u8> + Clone,
+    {
+        if max_depth == 0 {
+            return Ok(false);
+        }
+        while let Some(p) = pattern.take_first() {
+            let f = name_iter.peek().ok_or(Error::UnterminatedString)?;
+            #[cfg(test)]
+            println!("{} ~ {}", *p as char, *f as char);
+            match p {
+                b'\0' => return Ok(*f == b'\0'),
+                b'\\' => {
+                    match pattern.take_first() {
+                        // trailing escape
+                        Some(b'\0') | None => return Ok(false),
+                        // no match
+                        Some(p) if p != f => return Ok(false),
+                        // continue
+                        _ => (),
+                    }
+                }
+                b'?' => {
+                    if *f == b'\0' {
+                        return Ok(false);
+                    }
+                }
+                b'*' => {
+                    while name_iter.peek().is_some() {
+                        if compare_entry_inner(name_iter.clone(), pattern, max_depth - 1)? {
+                            return Ok(true);
+                        }
+                        name_iter.next().ok_or(Error::UnterminatedString)?;
+                    }
+                    return Ok(*pattern.first().ok_or(Error::UnterminatedString)? == b'\0');
+                }
+                // TODO
+                b'[' => todo!("patterns containing `[...]` sets are not supported"),
+                _ if p != f => return Ok(false),
+                _ => (),
+            }
+            name_iter.next().ok_or(Error::UnterminatedString)?;
+        }
+        Ok(false)
+    }
+    let name_iter = file_name.iter().copied().peekable();
+    compare_entry_inner(name_iter, pattern, 32)
 }
 
 fn parse_entry(f: &mut fat::File) -> Result<LoaderConfig, fat::Error> {
@@ -110,20 +196,20 @@ fn parse_entry(f: &mut fat::File) -> Result<LoaderConfig, fat::Error> {
     Ok(loader_config)
 }
 
-const ENTRY_DIRECTORY: &str = "/loader/entries/";
-
-fn default_entry_path(fs: &fat::Filesystem) -> Result<[u8; 260], fat::Error> {
+fn default_entry_path(fs: &fat::Filesystem) -> Result<[u8; 260], Error> {
     let mut f = match fs.open("/loader/loader.conf")? {
         fat::Node::File(f) => f,
-        _ => return Err(fat::Error::NotFound),
+        _ => return Err(fat::Error::NotFound.into()),
     };
-    let default_entry = default_entry_file(&mut f)?;
+    let default_entry_pattern = default_entry_pattern(&mut f)?;
+
+    let default_entry = find_entry(fs, &default_entry_pattern)?;
     let default_entry = ascii_strip(&default_entry);
 
     let mut entry_path = [0u8; 260];
     entry_path[0..ENTRY_DIRECTORY.len()].copy_from_slice(ENTRY_DIRECTORY.as_bytes());
-
-    entry_path[ENTRY_DIRECTORY.len()..ENTRY_DIRECTORY.len() + default_entry.len()]
+    entry_path[ENTRY_DIRECTORY.len()] = b'/';
+    entry_path[ENTRY_DIRECTORY.len() + 1..ENTRY_DIRECTORY.len() + default_entry.len() + 1]
         .copy_from_slice(default_entry.as_bytes());
     Ok(entry_path)
 }
@@ -134,7 +220,7 @@ pub fn load_default_entry(fs: &fat::Filesystem, info: &dyn boot::Info) -> Result
 
     let mut f = match fs.open(default_entry_path)? {
         fat::Node::File(f) => f,
-        _ => return Err(Error::FileError(fat::Error::NotFound)),
+        _ => return Err(Error::File(fat::Error::NotFound)),
     };
     let entry = parse_entry(&mut f)?;
 
@@ -173,16 +259,16 @@ mod tests {
         fs.init().expect("Error initialising filesystem");
 
         let mut f: crate::fat::File = fs.open("/loader/loader.conf").unwrap().try_into().unwrap();
-        let s = super::default_entry_file(&mut f).unwrap();
+        let s = super::default_entry_pattern(&mut f).unwrap();
         let s = super::ascii_strip(&s);
-        assert_eq!(s, "Clear-linux-kvm-5.0.6-318.conf");
+        assert_eq!(s, "Clear-linux-kvm-5.0.6-318");
 
         let default_entry_path = super::default_entry_path(&fs).unwrap();
         let default_entry_path = super::ascii_strip(&default_entry_path);
 
         assert_eq!(
             default_entry_path,
-            format!("/loader/entries/{}", s).as_str()
+            format!("/loader/entries/{}.conf", s).as_str()
         );
 
         let mut f: crate::fat::File = fs.open(default_entry_path).unwrap().try_into().unwrap();
@@ -192,5 +278,47 @@ mod tests {
         let s = super::ascii_strip(&entry.cmdline);
         let s = s.trim_matches(char::from(0));
         assert_eq!(s, "root=PARTUUID=ae06d187-e9fc-4d3b-9e5b-8e6ff28e894f console=tty0 console=ttyS0,115200n8 console=hvc0 quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp cryptomgr.notests rootfstype=ext4,btrfs,xfs kvm-intel.nested=1 rw");
+    }
+
+    macro_rules! entry_pattern_matches {
+        (match $entry:literal with {
+            $(
+                $( #[$attr:meta] )*
+                $id:ident: $pat:literal => $result:literal
+            ),* $(,)?
+        } ) => {
+            mod entry_pattern {
+                $(
+                    #[test]
+                    $( #[$attr] )*
+                    fn $id() {
+                        assert_eq!(super::super::compare_entry($entry, $pat).unwrap(), $result);
+                    }
+                )*
+            }
+        }
+    }
+
+    entry_pattern_matches! {
+        match b"foobar.conf\0" with {
+            empty: b"\0" => false,
+
+            exact: b"foobar.conf\0" => true,
+            inexact: b"barfoo.conf\0" => false,
+
+            wildcard: b"*\0" => true,
+            leading_wildcard: b"*.conf\0" => true,
+            internal_wildcard: b"foo*.conf\0" => true,
+            trailing_wildcard: b"foob*\0" => true,
+            mismatched_wildcard: b"bar*\0" => false,
+            wildcard_backtrack: b"*obar.conf\0" => true,
+
+            single_wildcard: b"fo?bar.conf\0" => true,
+            mismatched_single_wildcard: b"foo?bar.conf\0" => false,
+
+            escaped_regular_char: b"foo\\bar.conf\0" => true,
+            escaped_special_char: b"foo\\?ar.conf\0" => false,
+            trailing_escape: b"foobar.conf\\\0" => false,
+        }
     }
 }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -160,9 +160,10 @@ pub fn load_default_entry(fs: &fat::Filesystem, info: &dyn boot::Info) -> Result
 
 #[cfg(test)]
 mod tests {
+    use core::convert::TryInto;
+
     use crate::fat::Read;
     use crate::part::tests::*;
-    use core::convert::TryInto;
 
     #[test]
     fn test_default_entry() {

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -246,10 +246,9 @@ pub fn load_default_entry(fs: &fat::Filesystem, info: &dyn boot::Info) -> Result
 
 #[cfg(test)]
 mod tests {
-    use core::convert::TryInto;
-
     use crate::fat::Read;
     use crate::part::tests::*;
+    use core::convert::TryInto;
 
     #[test]
     fn test_default_entry() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@
 
 #![feature(alloc_error_handler)]
 #![feature(stmt_expr_attributes)]
+#![feature(slice_take)]
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(test, allow(unused_imports, dead_code))]


### PR DESCRIPTION
Resolves #183

This update implements matching of boot entry names against the pattern in the
`default` option from `loader/loader.conf`, intended to be compatible with the
behaviour of `systemd-boot`.

## Outstanding work

- [ ] implement `[..]` style patterns - deferred. Tracked in #191
- [x] better error handling, fewer panics
- [x] discuss use of unstable `slice_take` feature

