### PR TITLE
block: Improve block device portability by reducing hard-coded sector size

### DIFF
--- a/src/bzimage.rs
+++ b/src/bzimage.rs
@@ -14,6 +14,7 @@
 use atomic_refcell::AtomicRefCell;
 
 use crate::{
+    block::SectorBuf,
     boot::{E820Entry, Header, Info, Params},
     fat::{self, Read},
     mem::MemoryRegion,
@@ -62,7 +63,7 @@ impl Kernel {
             0 => 4,
             n => n as u32,
         };
-        let setup_bytes = (setup_sects + 1) * 512;
+        let setup_bytes = (setup_sects + 1) * SectorBuf::len() as u32;
         let remaining_bytes = f.get_size() - setup_bytes;
 
         let mut region = MemoryRegion::new(KERNEL_LOCATION, remaining_bytes as u64);

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -541,7 +541,7 @@ impl<'a> Read for File<'a> {
 impl<'a> SectorRead for Filesystem<'a> {
     fn read(&self, sector: u64, data: &mut [u8]) -> Result<(), crate::block::Error> {
         if self.start + sector > self.last {
-            Err(crate::block::Error::BlockIOError)
+            Err(crate::block::Error::BlockIO)
         } else {
             self.device.read(self.start + sector, data)
         }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::{
+    block::SectorBuf,
     boot,
     bzimage::{self, Kernel},
     common::ascii_strip,
@@ -48,15 +49,16 @@ const ENTRY_EXTENSION: &str = ".conf";
 fn default_entry_file(f: &mut fat::File) -> Result<[u8; 260], fat::Error> {
     let mut data = [0; 4096];
     assert!(f.get_size() as usize <= data.len());
+    assert!(data.len() >= SectorBuf::len());
 
     let mut entry_file_name = [0; 260];
     let mut offset = 0;
     loop {
-        match f.read(&mut data[offset..offset + 512]) {
+        match f.read(&mut data[offset..offset + SectorBuf::len()]) {
             Err(fat::Error::EndOfFile) => break,
             Err(e) => return Err(e),
             Ok(_) => {
-                offset += 512;
+                offset += SectorBuf::len();
             }
         }
     }
@@ -77,16 +79,17 @@ fn default_entry_file(f: &mut fat::File) -> Result<[u8; 260], fat::Error> {
 fn parse_entry(f: &mut fat::File) -> Result<LoaderConfig, fat::Error> {
     let mut data = [0; 4096];
     assert!(f.get_size() as usize <= data.len());
+    assert!(data.len() >= SectorBuf::len());
 
     let mut loader_config: LoaderConfig = unsafe { core::mem::zeroed() };
 
     let mut offset = 0;
     loop {
-        match f.read(&mut data[offset..offset + 512]) {
+        match f.read(&mut data[offset..offset + SectorBuf::len()]) {
             Err(fat::Error::EndOfFile) => break,
             Err(e) => return Err(e),
             Ok(_) => {
-                offset += 512;
+                offset += SectorBuf::len();
             }
         }
     }

--- a/src/part.rs
+++ b/src/part.rs
@@ -182,11 +182,11 @@ pub mod tests {
             let mut file = self.file.borrow_mut();
             match file.seek(SeekFrom::Start(sector * SectorBuf::len() as u64)) {
                 Ok(_) => {}
-                Err(_) => return Err(block::Error::BlockIOError),
+                Err(_) => return Err(block::Error::BlockIO),
             }
             match file.read(data) {
                 Ok(_) => {}
-                Err(_) => return Err(block::Error::BlockIOError),
+                Err(_) => return Err(block::Error::BlockIO),
             }
             Ok(())
         }


### PR DESCRIPTION
This PR proposes improving block device portability by reducing hard-coded sector size.

The current implementation assumes that a sector size is always 512 bytes. This can be a blocking issue when supporting block devices with other sector sizes. To improve the code portability, 4b44f79c0e48cc2519cd02f12d2058c0302b56e4 introduces `SectorBuf` that represents a single sector buffer instead of `[u8; 512]`.

5c1d9429bd98227ff9c3471141677a5a4df62ce8 improves the `VirtioBlockDevice::request()` error handling.