### PR TITLE
build: Use Rust toolchain specified in rust-toolchain.toml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
       - name: Install rust-src
         run: rustup component add rust-src
       - name: Install clippy

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,24 +9,13 @@ jobs:
     if: github.event_name == 'pull_request'
     name: Build
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        rust:
-          - nightly-2022-06-10
-        target:
-          - x86_64-unknown-linux-gnu
     steps:
       - name: Code checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Install Rust toolchain (${{ matrix.rust }})
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
       - name: Install rust-src
         run: rustup component add rust-src
       - name: Install clippy

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -3,9 +3,13 @@ name: Rust-Hypervisor-Firmware's Docker image update
 on:
   push:
     branches: main
-    paths: resources/Dockerfile
+    paths:
+      - resources/Dockerfile
+      - rust-toolchain.toml
   pull_request:
-    paths: resources/Dockerfile
+    paths:
+      - resources/Dockerfile
+      - rust-toolchain.toml
 
 jobs:
   main:
@@ -14,28 +18,25 @@ jobs:
       - name: Code checkout
         uses: actions/checkout@v2
 
+      - name: Get active Rust toolchain
+        id: get-toolchain
+        run: echo "toolchain=`rustup show active-toolchain | cut -d ' ' -f1`" >> $GITHUB_ENV
+
       - name: Login to DockerHub
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.repository == 'cloud-hypervisor/rust-hypervisor-firmware' && github.event_name == 'push' }}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
-        if: ${{ github.event_name == 'push' }}
+      - name: Build
         uses: docker/build-push-action@v2
         with:
           file: ./resources/Dockerfile
+          build-args: |
+            RUST_TOOLCHAIN=${{ env.toolchain }}
           platforms: linux/amd64
-          push: true
-          tags: rusthypervisorfirmware/dev:latest
-
-      - name: Build only
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/build-push-action@v2
-        with:
-          file: ./resources/Dockerfile
-          platforms: linux/amd64
+          push: ${{ github.repository == 'cloud-hypervisor/rust-hypervisor-firmware' && github.event_name == 'push' }}
           tags: rusthypervisorfirmware/dev:latest
 
       - name: Image digest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
       - name: Install rust-src
         run: rustup component add rust-src
       - name: Build (release)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,24 +9,13 @@ jobs:
     if: github.event_name == 'create' && github.event.ref_type == 'tag'
     name: Release
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        rust:
-          - nightly-2022-06-10
-        target:
-          - x86_64-unknown-linux-gnu
     steps:
       - name: Code checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Install Rust toolchain (${{ matrix.rust }})
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
       - name: Install rust-src
         run: rustup component add rust-src
       - name: Build (release)

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04 as dev
 
 ARG TARGETARCH
-ARG RUST_TOOLCHAIN="nightly-2022-06-10"
+ARG RUST_TOOLCHAIN
 ARG RHF_SRC_DIR="/rust-hypervisor-firmware"
 ARG RHF_BUILD_DIR="$RHF_SRC_DIR/build"
 ARG CARGO_REGISTRY_DIR="$RHF_BUILD_DIR/cargo_registry"

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -400,12 +400,14 @@ cmd_build-container() {
     cp $RHF_DOCKERFILE $BUILD_DIR
 
     [ $(uname -m) = "x86_64" ] && TARGETARCH="amd64"
+    RUST_TOOLCHAIN="$(rustup show active-toolchain | cut -d ' ' -f1)"
 
     $DOCKER_RUNTIME build \
 	   --target $container_type \
 	   -t $CTR_IMAGE \
 	   -f $BUILD_DIR/Dockerfile \
-	   --build-arg TARGETARCH=$TARGETARCH \
+       --build-arg TARGETARCH=$TARGETARCH \
+       --build-arg RUST_TOOLCHAIN=$RUST_TOOLCHAIN \
 	   $BUILD_DIR
 }
 


### PR DESCRIPTION
This PR proposes simplifying Rust toolchain selection on GitHub Actions. The current CI config specifies the same toolchain version in multiple locations. This PR changes to use toolchain version defined in rust-toolchain.toml on every CI build.