### PR TITLE
fat: Support clusters with multiple sectors

### DIFF
--- a/scripts/make-test-disks.sh
+++ b/scripts/make-test-disks.sh
@@ -26,6 +26,11 @@ make_test_disks() {
         dd if=test_data/a/b/c/d of=test_data/a/b/c/$n count=$n bs=1
     done
 
+    mkdir -p test_data/largedir
+    for x in `seq 0 100`; do
+        touch test_data/largedir/$x
+    done
+
     touch test_data/longfilenametest
 
     export MTOOLS_SKIP_CHECK=1

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -191,6 +191,7 @@ pub struct File<'a> {
 pub struct Directory<'a> {
     filesystem: &'a Filesystem<'a>,
     cluster: Option<u32>,
+    first_sector: u32,
     sector: u32,
     offset: usize,
 }
@@ -443,6 +444,7 @@ impl<'a> Directory<'a> {
         if offset != 0 {
             return Err(Error::Unsupported);
         }
+        self.sector = self.first_sector;
         self.offset = 0;
         Ok(())
     }
@@ -792,6 +794,7 @@ impl<'a> Filesystem<'a> {
                 Ok(Directory {
                     filesystem: self,
                     cluster: None,
+                    first_sector: root_directory_start,
                     sector: root_directory_start,
                     offset: 0,
                 })
@@ -799,6 +802,7 @@ impl<'a> Filesystem<'a> {
             FatType::FAT32 => Ok(Directory {
                 filesystem: self,
                 cluster: Some(self.root_cluster),
+                first_sector: 0,
                 sector: 0,
                 offset: 0,
             }),
@@ -821,6 +825,7 @@ impl<'a> Filesystem<'a> {
         Ok(Directory {
             filesystem: self,
             cluster: Some(cluster),
+            first_sector: 0,
             sector: 0,
             offset: 0,
         })

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -340,17 +340,19 @@ impl<'a> Directory<'a> {
                 }
             };
 
+            let num_dirs = SectorBuf::len() / 32;
+
             let dirs: &[FatDirectory] = unsafe {
                 core::slice::from_raw_parts(
                     data.as_bytes().as_ptr() as *const FatDirectory,
-                    SectorBuf::len() / 32,
+                    num_dirs,
                 )
             };
 
             let lfns: &[FatLongNameEntry] = unsafe {
                 core::slice::from_raw_parts(
                     data.as_bytes().as_ptr() as *const FatLongNameEntry,
-                    SectorBuf::len() / 32,
+                    num_dirs,
                 )
             };
 
@@ -400,6 +402,10 @@ impl<'a> Directory<'a> {
                 };
 
                 self.offset = i + 1;
+                if self.offset >= num_dirs {
+                    self.sector += (self.offset / num_dirs) as u32;
+                    self.offset %= num_dirs;
+                }
                 return Ok(entry);
             }
             self.sector += 1;

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -1134,6 +1134,29 @@ mod tests {
     }
 
     #[test]
+    fn test_fat_large_directory() {
+        let images = fat_test_image_paths();
+
+        for image in &images {
+            let disk = FakeDisk::new(&image);
+            let len = disk.len();
+            let mut fs = crate::fat::Filesystem::new(&disk, 0, len);
+            fs.init().expect("Error initialising filesystem");
+
+            let mut d = fs.root().unwrap();
+            let de = d.next_entry().unwrap();
+            assert_eq!(&de.name, b"A          ");
+            let de = d.next_entry().unwrap();
+            assert_eq!(&de.name, b"LARGEDIR   ");
+
+            let mut d = fs.get_directory(de.cluster).unwrap();
+            while d.has_next().unwrap() {
+                d.next_entry().unwrap();
+            }
+        }
+    }
+
+    #[test]
     fn test_fat_long_file_name() {
         let images = fat_test_image_paths();
 


### PR DESCRIPTION
The current implementation is lacking the support for FAT with clusters made of more than one sector. This is fixed by having the internal offset being rounded modulo the size of the list of directories (16) along with updating the current sector.
But this also requires a second patch for operating `Seek` correctly. The sector can't always be reset to 0 (like we do with the offset), which is why an additional field storing the proper value is added to the Directory structure. This allows for a proper reset of the sector related to the directory.

Fixes #199