### PR TITLE
layout: Introduce `layout` for memory mapping

### DIFF
--- a/src/arch/x86_64/layout.rs
+++ b/src/arch/x86_64/layout.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Akira Moroo
+
+use core::{cell::UnsafeCell, ops::Range};
+
+use crate::layout::{MemoryAttribute, MemoryDescriptor, MemoryLayout};
+
+extern "Rust" {
+    static ram_min: UnsafeCell<()>;
+    static code_start: UnsafeCell<()>;
+    static code_end: UnsafeCell<()>;
+    static data_start: UnsafeCell<()>;
+    static data_end: UnsafeCell<()>;
+    static stack_start: UnsafeCell<()>;
+    static stack_end: UnsafeCell<()>;
+}
+
+pub fn header_range() -> Range<usize> {
+    unsafe { (ram_min.get() as _)..(code_start.get() as _) }
+}
+
+pub fn code_range() -> Range<usize> {
+    unsafe { (code_start.get() as _)..(code_end.get() as _) }
+}
+
+pub fn data_range() -> Range<usize> {
+    unsafe { (data_start.get() as _)..(data_end.get() as _) }
+}
+
+pub fn stack_range() -> Range<usize> {
+    unsafe { (stack_start.get() as _)..(stack_end.get() as _) }
+}
+
+const NUM_MEM_DESCS: usize = 4;
+
+pub static MEM_LAYOUT: MemoryLayout<NUM_MEM_DESCS> = [
+    MemoryDescriptor {
+        name: "PVH Header",
+        range: header_range,
+        attribute: MemoryAttribute::Data,
+    },
+    MemoryDescriptor {
+        name: "Code",
+        range: code_range,
+        attribute: MemoryAttribute::Code,
+    },
+    MemoryDescriptor {
+        name: "Data",
+        range: data_range,
+        attribute: MemoryAttribute::Data,
+    },
+    MemoryDescriptor {
+        name: "Stack",
+        range: stack_range,
+        attribute: MemoryAttribute::Data,
+    },
+];

--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -4,5 +4,6 @@
 #[cfg(not(test))]
 pub mod asm;
 pub mod gdt;
+pub mod layout;
 pub mod paging;
 pub mod sse;

--- a/src/arch/x86_64/ram32.s
+++ b/src/arch/x86_64/ram32.s
@@ -42,7 +42,7 @@ jump_to_64bit:
     # load a 64-bit code segment into our GDT.
     lgdtl GDT64_PTR
     # Initialize the stack pointer (Rust code always uses the stack)
-    movl $stack_start, %esp
+    movl $stack_end, %esp
     # Set segment registers to a 64-bit segment.
     movw $0x10, %ax
     movw %ax, %ds

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -35,6 +35,7 @@ use r_efi::{
 };
 
 use crate::boot;
+use crate::layout;
 use crate::rtc;
 
 mod alloc;
@@ -914,17 +915,6 @@ fn extract_path(device_path: &DevicePathProtocol, path: &mut [u8]) {
     }
 }
 
-extern "C" {
-    #[link_name = "ram_min"]
-    static RAM_MIN: c_void;
-    #[link_name = "text_start"]
-    static TEXT_START: c_void;
-    #[link_name = "text_end"]
-    static TEXT_END: c_void;
-    #[link_name = "stack_start"]
-    static STACK_START: c_void;
-}
-
 const PAGE_SIZE: u64 = 4096;
 const HEAP_SIZE: usize = 256 * 1024 * 1024;
 
@@ -942,34 +932,22 @@ fn populate_allocator(info: &dyn boot::Info, image_address: u64, image_size: u64
         }
     }
 
-    let ram_min = unsafe { &RAM_MIN as *const _ as u64 };
-    let text_start = unsafe { &TEXT_START as *const _ as u64 };
-    let text_end = unsafe { &TEXT_END as *const _ as u64 };
-    let stack_start = unsafe { &STACK_START as *const _ as u64 };
-    assert!(ram_min % PAGE_SIZE == 0);
-    assert!(text_start % PAGE_SIZE == 0);
-    assert!(text_end % PAGE_SIZE == 0);
-    assert!(stack_start % PAGE_SIZE == 0);
+    #[cfg(target_arch = "x86_64")]
+    use crate::arch::x86_64::layout::MEM_LAYOUT;
 
-    // Add ourselves
-    ALLOCATOR.borrow_mut().allocate_pages(
-        efi::ALLOCATE_ADDRESS,
-        efi::RUNTIME_SERVICES_DATA,
-        (text_start - ram_min) / PAGE_SIZE,
-        ram_min,
-    );
-    ALLOCATOR.borrow_mut().allocate_pages(
-        efi::ALLOCATE_ADDRESS,
-        efi::RUNTIME_SERVICES_CODE,
-        (text_end - text_start) / PAGE_SIZE,
-        text_start,
-    );
-    ALLOCATOR.borrow_mut().allocate_pages(
-        efi::ALLOCATE_ADDRESS,
-        efi::RUNTIME_SERVICES_DATA,
-        (stack_start - text_end) / PAGE_SIZE,
-        text_end,
-    );
+    for descriptor in MEM_LAYOUT {
+        let memory_type = match descriptor.attribute {
+            layout::MemoryAttribute::Code => efi::RUNTIME_SERVICES_CODE,
+            layout::MemoryAttribute::Data => efi::RUNTIME_SERVICES_DATA,
+            layout::MemoryAttribute::Unusable => efi::UNUSABLE_MEMORY,
+        };
+        ALLOCATOR.borrow_mut().allocate_pages(
+            efi::ALLOCATE_ADDRESS,
+            memory_type,
+            descriptor.page_count() as u64,
+            descriptor.range_start() as u64,
+        );
+    }
 
     // Add the loaded binary
     ALLOCATOR.borrow_mut().allocate_pages(

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Akira Moroo
+
+use core::ops::Range;
+
+#[derive(Clone, Copy)]
+pub enum MemoryAttribute {
+    Code,
+    Data,
+    #[allow(dead_code)]
+    Unusable,
+}
+
+#[derive(Clone, Copy)]
+pub struct MemoryDescriptor {
+    pub name: &'static str,
+    pub range: fn() -> Range<usize>,
+    pub attribute: MemoryAttribute,
+}
+
+impl MemoryDescriptor {
+    const PAGE_SIZE: usize = 0x1000;
+
+    pub fn range_start(&self) -> usize {
+        let addr = (self.range)().start;
+        assert!(addr % Self::PAGE_SIZE == 0);
+        addr
+    }
+
+    pub fn range_end(&self) -> usize {
+        let addr = (self.range)().end;
+        assert!(addr % Self::PAGE_SIZE == 0);
+        addr
+    }
+
+    pub fn page_count(&self) -> usize {
+        (self.range_end() - self.range_start()) / Self::PAGE_SIZE
+    }
+}
+
+pub type MemoryLayout<const NUM_MEM_DESCS: usize> = [MemoryDescriptor; NUM_MEM_DESCS];

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ mod efi;
 mod fat;
 #[cfg(all(test, feature = "integration_tests"))]
 mod integration;
+mod layout;
 mod loader;
 mod mem;
 mod part;

--- a/x86_64-unknown-none.ld
+++ b/x86_64-unknown-none.ld
@@ -18,29 +18,30 @@ SECTIONS
 
   /* These sections are mapped into RAM from the file. Omitting :ram from
      later sections avoids emitting empty sections in the final binary.       */
-  data_start = .;
   .rodata : { *(.rodata .rodata.*) } :ram
   . = ALIGN(4K);
-  text_start = .;
+  code_start = .;
   .text   : { *(.text .text.*)     }
   .text32 : { *(.text32)           }
   . = ALIGN(4K);
-  text_end = .;
+  code_end = .;
+
+  data_start = .;
   .data   : { *(.data .data.*)     }
-  data_size = . - data_start;
 
   /* The BSS section isn't mapped from file data. It is just zeroed in RAM. */
   .bss : {
-    bss_start = .;
     *(.bss .bss.*)
-    bss_size = . - bss_start;
   }
+  . = ALIGN(4K);
+  data_end = .;
 
   /* Our stack grows down and is page-aligned. TODO: Add stack guard pages. */
-  .stack (NOLOAD) : ALIGN(4K) { . += 128K; }
   stack_start = .;
+  .stack (NOLOAD) : ALIGN(4K) { . += 128K; }
   /* ram32.s only maps the first 2 MiB, and that must include the stack. */
   ASSERT((. <= 2M), "Stack overflows initial identity-mapped memory region")
+  stack_end = .;
 
   /* Strip symbols from the output binary (comment out to get symbols) */
   /DISCARD/ : {


### PR DESCRIPTION
This commit introduces base `layout` mod and x86_64 specific `layout` mod to provide architecture-independent memory mapping info for EFI compatible layer.

Signed-off-by: Akira Moroo <retrage01@gmail.com>