### PR TITLE
build: Update toolchain to nightly-2022-11-12

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-06-10"
+channel = "nightly-2022-11-12"
 components = ["rust-src", "clippy", "rustfmt"]
 targets = ["x86_64-unknown-linux-gnu"]
 profile = "default"

--- a/src/efi/alloc.rs
+++ b/src/efi/alloc.rs
@@ -59,7 +59,7 @@ impl Allocator {
 
             a.in_use = true;
             a.next_allocation = None;
-            a.descriptor.r#type = memory_type as u32;
+            a.descriptor.r#type = memory_type;
             a.descriptor.number_of_pages = page_count;
             a.descriptor.physical_start = address;
             a.descriptor.attribute = attributes;
@@ -90,7 +90,7 @@ impl Allocator {
         let next_allocation = &mut self.allocations[next];
         next_allocation.in_use = true;
         next_allocation.next_allocation = None;
-        next_allocation.descriptor.r#type = memory_type as u32;
+        next_allocation.descriptor.r#type = memory_type;
         next_allocation.descriptor.number_of_pages = page_count;
         next_allocation.descriptor.physical_start = address;
         next_allocation.descriptor.attribute = attributes;
@@ -120,7 +120,7 @@ impl Allocator {
         while cur.is_some() {
             let a = &mut self.allocations[cur.unwrap()];
 
-            if a.descriptor.r#type != efi::CONVENTIONAL_MEMORY as u32 {
+            if a.descriptor.r#type != efi::CONVENTIONAL_MEMORY {
                 cur = a.next_allocation;
                 continue;
             }
@@ -219,7 +219,7 @@ impl Allocator {
 
         // Identical special case
         if self.allocations[dest].descriptor.number_of_pages == page_count {
-            self.allocations[dest].descriptor.r#type = memory_type as u32;
+            self.allocations[dest].descriptor.r#type = memory_type;
             return (
                 Status::SUCCESS,
                 self.allocations[dest].descriptor.physical_start,
@@ -273,7 +273,7 @@ impl Allocator {
             }
         }
 
-        self.allocations[assigned].descriptor.r#type = memory_type as u32;
+        self.allocations[assigned].descriptor.r#type = memory_type;
         self.allocations[assigned].descriptor.attribute |= match memory_type {
             efi::RUNTIME_SERVICES_CODE | efi::RUNTIME_SERVICES_DATA => r_efi::efi::MEMORY_RUNTIME,
             _ => 0,
@@ -299,8 +299,8 @@ impl Allocator {
             let next = next_allocation.unwrap();
 
             // If next allocation has the same type and are contiguous then merge
-            if self.allocations[current].descriptor.r#type == efi::CONVENTIONAL_MEMORY as u32
-                && self.allocations[next].descriptor.r#type == efi::CONVENTIONAL_MEMORY as u32
+            if self.allocations[current].descriptor.r#type == efi::CONVENTIONAL_MEMORY
+                && self.allocations[next].descriptor.r#type == efi::CONVENTIONAL_MEMORY
                 && self.allocations[next].descriptor.physical_start
                     == self.allocations[current].descriptor.physical_start
                         + self.allocations[current].descriptor.number_of_pages * PAGE_SIZE
@@ -326,7 +326,7 @@ impl Allocator {
             let a = &mut self.allocations[cur.unwrap()];
 
             if address == a.descriptor.physical_start {
-                a.descriptor.r#type = efi::CONVENTIONAL_MEMORY as u32;
+                a.descriptor.r#type = efi::CONVENTIONAL_MEMORY;
                 self.merge_free_memory();
                 return Status::SUCCESS;
             }
@@ -468,7 +468,7 @@ mod tests {
         );
         assert_eq!(
             allocator.allocations[0].descriptor.r#type,
-            efi::CONVENTIONAL_MEMORY as u32
+            efi::CONVENTIONAL_MEMORY
         );
 
         // Add range 3.5GiB to 4.0
@@ -494,7 +494,7 @@ mod tests {
         );
         assert_eq!(
             allocator.allocations[2].descriptor.r#type,
-            efi::MEMORY_MAPPED_IO as u32
+            efi::MEMORY_MAPPED_IO
         );
 
         // Add memory from 4GiB to 8GiB of conventional
@@ -539,7 +539,7 @@ mod tests {
         );
         assert_eq!(
             allocator.allocations[0].descriptor.r#type,
-            efi::CONVENTIONAL_MEMORY as u32
+            efi::CONVENTIONAL_MEMORY
         );
 
         assert!(allocator.allocations[4].in_use);
@@ -554,7 +554,7 @@ mod tests {
         );
         assert_eq!(
             allocator.allocations[4].descriptor.r#type,
-            efi::CONVENTIONAL_MEMORY as u32
+            efi::CONVENTIONAL_MEMORY
         );
     }
 
@@ -708,18 +708,18 @@ mod tests {
 
         assert_eq!(descriptors[0].physical_start, 0);
         assert_eq!(descriptors[0].number_of_pages, 1);
-        assert_eq!(descriptors[0].r#type, efi::CONVENTIONAL_MEMORY as u32);
+        assert_eq!(descriptors[0].r#type, efi::CONVENTIONAL_MEMORY);
 
         assert_eq!(descriptors[1].physical_start, 0x1000);
         assert_eq!(descriptors[1].number_of_pages, 1);
-        assert_eq!(descriptors[1].r#type, efi::LOADER_DATA as u32);
+        assert_eq!(descriptors[1].r#type, efi::LOADER_DATA);
 
         assert_eq!(descriptors[2].physical_start, 0x2000);
         assert_eq!(
             descriptors[2].number_of_pages,
             (0x9fc00 / super::PAGE_SIZE) - 2
         );
-        assert_eq!(descriptors[2].r#type, efi::CONVENTIONAL_MEMORY as u32);
+        assert_eq!(descriptors[2].r#type, efi::CONVENTIONAL_MEMORY);
 
         // 4KiB at 0x1000
         assert_eq!(
@@ -733,18 +733,18 @@ mod tests {
 
         assert_eq!(descriptors[0].physical_start, 0);
         assert_eq!(descriptors[0].number_of_pages, 1);
-        assert_eq!(descriptors[0].r#type, efi::CONVENTIONAL_MEMORY as u32);
+        assert_eq!(descriptors[0].r#type, efi::CONVENTIONAL_MEMORY);
 
         assert_eq!(descriptors[1].physical_start, 0x1000);
         assert_eq!(descriptors[1].number_of_pages, 1);
-        assert_eq!(descriptors[1].r#type, efi::LOADER_DATA as u32);
+        assert_eq!(descriptors[1].r#type, efi::LOADER_DATA);
 
         assert_eq!(descriptors[2].physical_start, 0x2000);
         assert_eq!(
             descriptors[2].number_of_pages,
             (0x9fc00 / super::PAGE_SIZE) - 2
         );
-        assert_eq!(descriptors[2].r#type, efi::CONVENTIONAL_MEMORY as u32);
+        assert_eq!(descriptors[2].r#type, efi::CONVENTIONAL_MEMORY);
 
         // 4KiB at 0
         assert_eq!(
@@ -758,18 +758,18 @@ mod tests {
 
         assert_eq!(descriptors[0].physical_start, 0);
         assert_eq!(descriptors[0].number_of_pages, 1);
-        assert_eq!(descriptors[0].r#type, efi::LOADER_DATA as u32);
+        assert_eq!(descriptors[0].r#type, efi::LOADER_DATA);
 
         assert_eq!(descriptors[1].physical_start, 0x1000);
         assert_eq!(descriptors[1].number_of_pages, 1);
-        assert_eq!(descriptors[1].r#type, efi::LOADER_DATA as u32);
+        assert_eq!(descriptors[1].r#type, efi::LOADER_DATA);
 
         assert_eq!(descriptors[2].physical_start, 0x2000);
         assert_eq!(
             descriptors[2].number_of_pages,
             (0x9fc00 / super::PAGE_SIZE) - 2
         );
-        assert_eq!(descriptors[2].r#type, efi::CONVENTIONAL_MEMORY as u32);
+        assert_eq!(descriptors[2].r#type, efi::CONVENTIONAL_MEMORY);
     }
 
     #[test]
@@ -797,18 +797,18 @@ mod tests {
 
         assert_eq!(descriptors[0].physical_start, 0);
         assert_eq!(descriptors[0].number_of_pages, 1);
-        assert_eq!(descriptors[0].r#type, efi::CONVENTIONAL_MEMORY as u32);
+        assert_eq!(descriptors[0].r#type, efi::CONVENTIONAL_MEMORY);
 
         assert_eq!(descriptors[1].physical_start, 0x1000);
         assert_eq!(descriptors[1].number_of_pages, 1);
-        assert_eq!(descriptors[1].r#type, efi::LOADER_DATA as u32);
+        assert_eq!(descriptors[1].r#type, efi::LOADER_DATA);
 
         assert_eq!(descriptors[2].physical_start, 0x2000);
         assert_eq!(
             descriptors[2].number_of_pages,
             (0x9fc00 / super::PAGE_SIZE) - 2
         );
-        assert_eq!(descriptors[2].r#type, efi::CONVENTIONAL_MEMORY as u32);
+        assert_eq!(descriptors[2].r#type, efi::CONVENTIONAL_MEMORY);
 
         assert_eq!(allocator.free_pages(0x1000), Status::SUCCESS);
 

--- a/src/efi/block.rs
+++ b/src/efi/block.rs
@@ -150,7 +150,7 @@ pub extern "efiapi" fn write_blocks(
     let wrapper = unsafe { &*wrapper };
 
     let block_size = wrapper.media.block_size as usize;
-    let blocks = (size / block_size) as usize;
+    let blocks = size / block_size;
     let mut region = crate::mem::MemoryRegion::new(buffer as u64, size as u64);
 
     for i in 0..blocks {

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -391,12 +391,9 @@ pub extern "efiapi" fn allocate_pages(
     let (status, new_address) =
         ALLOCATOR
             .borrow_mut()
-            .allocate_pages(
-                allocate_type,
-                memory_type,
-                pages as u64,
-                unsafe { *address } as u64,
-            );
+            .allocate_pages(allocate_type, memory_type, pages as u64, unsafe {
+                *address
+            });
     if status == Status::SUCCESS {
         unsafe {
             *address = new_address;
@@ -1077,7 +1074,7 @@ pub fn efi_exec(
                 0x22,
                 &[0x00, 0x80, 0xc7, 0x3c, 0x88, 0x81],
             ),
-            vendor_table: acpi_rsdp_ptr as u64 as *mut _,
+            vendor_table: acpi_rsdp_ptr as *mut _,
         }
     } else {
         efi::ConfigurationTable {

--- a/src/efi/var.rs
+++ b/src/efi/var.rs
@@ -72,7 +72,7 @@ impl VariableAllocator {
             return efi::Status::INVALID_PARAMETER;
         }
         let index = self.find(name, guid);
-        if index == None {
+        if index.is_none() {
             return efi::Status::NOT_FOUND;
         }
         let a = &self.allocations[index.unwrap()];
@@ -113,7 +113,7 @@ impl VariableAllocator {
             return efi::Status::INVALID_PARAMETER;
         }
         let index = self.find(name, guid);
-        if index == None {
+        if index.is_none() {
             // new variable
             if size == 0 {
                 return efi::Status::NOT_FOUND;

--- a/src/efi/var.rs
+++ b/src/efi/var.rs
@@ -52,12 +52,8 @@ impl VariableAllocator {
         let mut name: Vec<u16> = Vec::new();
         name.extend_from_slice(s);
         let guid = unsafe { &*guid };
-        for i in 0..self.allocations.len() {
-            if name == self.allocations[i].name && guid == &self.allocations[i].guid {
-                return Some(i);
-            }
-        }
-        None
+        (0..self.allocations.len())
+            .find(|&i| name == self.allocations[i].name && guid == &self.allocations[i].guid)
     }
 
     pub fn get(

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -857,7 +857,7 @@ impl<'a> Filesystem<'a> {
             // residual is what is left
             let sub = match &residual[1..]
                 .find('/')
-                .or_else(|| (&residual[1..]).find('\\'))
+                .or_else(|| (residual[1..]).find('\\'))
             {
                 None => {
                     let sub = &residual[1..];

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -73,7 +73,7 @@ mod tests {
                 .join("cloud-init")
                 .join("clear")
                 .join("openstack");
-            fs::create_dir_all(&cloud_init_directory.join("latest"))
+            fs::create_dir_all(cloud_init_directory.join("latest"))
                 .expect("Expect creating cloud-init directory to succeed");
             let source_file_dir = std::env::current_dir()
                 .unwrap()
@@ -101,15 +101,15 @@ mod tests {
                 .write_all(user_data_string.as_bytes())
                 .expect("Expected writing out user_data to succeed");
             std::process::Command::new("mkdosfs")
-                .args(&["-n", "config-2"])
-                .args(&["-C", cloudinit_file_path.as_str()])
+                .args(["-n", "config-2"])
+                .args(["-C", cloudinit_file_path.as_str()])
                 .arg("8192")
                 .output()
                 .expect("Expect creating disk image to succeed");
             std::process::Command::new("mcopy")
                 .arg("-o")
-                .args(&["-i", cloudinit_file_path.as_str()])
-                .args(&["-s", cloud_init_directory.to_str().unwrap(), "::"])
+                .args(["-i", cloudinit_file_path.as_str()])
+                .args(["-s", cloud_init_directory.to_str().unwrap(), "::"])
                 .output()
                 .expect("Expect copying files to disk image to succeed");
             cloudinit_file_path
@@ -156,8 +156,8 @@ mod tests {
                 .expect("Expected writing out network-config to succeed");
 
             std::process::Command::new("mkdosfs")
-                .args(&["-n", "cidata"])
-                .args(&["-C", cloudinit_file_path.as_str()])
+                .args(["-n", "cidata"])
+                .args(["-C", cloudinit_file_path.as_str()])
                 .arg("8192")
                 .output()
                 .expect("Expect creating disk image to succeed");
@@ -167,8 +167,8 @@ mod tests {
                 .for_each(|x| {
                     std::process::Command::new("mcopy")
                         .arg("-o")
-                        .args(&["-i", cloudinit_file_path.as_str()])
-                        .args(&["-s", cloud_init_directory.join(x).to_str().unwrap(), "::"])
+                        .args(["-i", cloudinit_file_path.as_str()])
+                        .args(["-s", cloud_init_directory.join(x).to_str().unwrap(), "::"])
                         .output()
                         .expect("Expect copying files to disk image to succeed");
                 });
@@ -215,7 +215,7 @@ mod tests {
 
             // losetup -d <loopback_device>
             std::process::Command::new("losetup")
-                .args(&["-d", self.loopback_device.as_str()])
+                .args(["-d", self.loopback_device.as_str()])
                 .output()
                 .expect("Expect removing loopback device to succeed");
         }
@@ -266,7 +266,7 @@ mod tests {
         std::process::Command::new("dmsetup")
             .arg("create")
             .arg(windows_snapshot_cow.as_str())
-            .args(&[
+            .args([
                 "--table",
                 format!(
                     "0 {} linear {} 0",
@@ -289,7 +289,7 @@ mod tests {
         std::process::Command::new("dmsetup")
             .arg("create")
             .arg(windows_snapshot.as_str())
-            .args(&[
+            .args([
                 "--table",
                 format!(
                     "0 {} snapshot /dev/mapper/windows-base /dev/mapper/{} P 8",
@@ -315,14 +315,14 @@ mod tests {
     fn prepare_os_disk(tmp_dir: &TempDir, image_name: &str) -> String {
         let src_osdisk = dirs::home_dir().unwrap().join("workloads").join(image_name);
         let dest_osdisk = tmp_dir.path().join(image_name);
-        fs::copy(&src_osdisk, &dest_osdisk).expect("Expect copying OS disk to succeed");
+        fs::copy(src_osdisk, &dest_osdisk).expect("Expect copying OS disk to succeed");
 
         dest_osdisk.to_str().unwrap().to_owned()
     }
 
     fn prepare_tap(net: &GuestNetworkConfig) {
         assert!(std::process::Command::new("bash")
-            .args(&[
+            .args([
                 "-c",
                 &format!("sudo ip tuntap add name {} mode tap", net.tap_name),
             ])
@@ -331,7 +331,7 @@ mod tests {
             .success());
 
         assert!(std::process::Command::new("bash")
-            .args(&[
+            .args([
                 "-c",
                 &format!("sudo ip addr add {}/24 dev {}", net.host_ip, net.tap_name),
             ])
@@ -340,7 +340,7 @@ mod tests {
             .success());
 
         assert!(std::process::Command::new("bash")
-            .args(&["-c", &format!("sudo ip link set dev {} up", net.tap_name)])
+            .args(["-c", &format!("sudo ip link set dev {} up", net.tap_name)])
             .status()
             .expect("Expected upping interface to work")
             .success());
@@ -348,7 +348,7 @@ mod tests {
 
     fn cleanup_tap(net: &GuestNetworkConfig) {
         assert!(std::process::Command::new("bash")
-            .args(&[
+            .args([
                 "-c",
                 &format!("sudo ip tuntap de name {} mode tap", net.tap_name),
             ])
@@ -491,7 +491,7 @@ mod tests {
                 .join("workloads")
                 .join("cloud-hypervisor");
             let mut c = Command::new(clh_path.to_str().unwrap());
-            c.args(&[
+            c.args([
                 "--console",
                 "off",
                 "--serial",
@@ -523,7 +523,7 @@ mod tests {
             net: &GuestNetworkConfig,
         ) -> Child {
             let mut c = Command::new("qemu-system-x86_64");
-            c.args(&[
+            c.args([
                 "-machine",
                 "q35,accel=kvm",
                 "-cpu",
@@ -685,7 +685,7 @@ mod tests {
             prepare_tap(&net);
 
             let mut c = Command::new("qemu-system-x86_64");
-            c.args(&[
+            c.args([
                 "-machine",
                 "q35,accel=kvm",
                 "-cpu",
@@ -771,7 +771,7 @@ mod tests {
                 .join("workloads")
                 .join("cloud-hypervisor");
             let mut c = Command::new(clh_path.to_str().unwrap());
-            c.args(&[
+            c.args([
                 "--cpus",
                 "boot=2,kvm_hyperv=on",
                 "--memory",

--- a/src/pci.rs
+++ b/src/pci.rs
@@ -192,7 +192,7 @@ impl PciDevice {
 
         //0x24 offset is last bar
         while current_bar_offset <= 0x24 {
-            #[allow(clippy::blacklisted_name)]
+            #[allow(clippy::disallowed_names)]
             let bar = self.read_u32(current_bar_offset);
 
             // lsb is 1 for I/O space bars
@@ -211,7 +211,7 @@ impl PciDevice {
                         self.bars[current_bar].address = u64::from(bar & 0xffff_fff0);
                         current_bar_offset += 4;
 
-                        #[allow(clippy::blacklisted_name)]
+                        #[allow(clippy::disallowed_names)]
                         let bar = self.read_u32(current_bar_offset);
                         self.bars[current_bar].address += u64::from(bar) << 32;
                     }
@@ -223,7 +223,7 @@ impl PciDevice {
             current_bar_offset += 4;
         }
 
-        #[allow(clippy::blacklisted_name)]
+        #[allow(clippy::disallowed_names)]
         for bar in &self.bars {
             log!("Bar: type={:?} address={:x}", bar.bar_type, bar.address);
         }
@@ -308,7 +308,7 @@ impl VirtioTransport for VirtioPciTransport {
                 //         le32 length;    /* Length of the structure, in bytes. */
                 // };
                 let cfg_type = self.device.read_u8(cap_next + 3);
-                #[allow(clippy::blacklisted_name)]
+                #[allow(clippy::disallowed_names)]
                 let bar = self.device.read_u8(cap_next + 4);
                 let offset = self.device.read_u32(cap_next + 8);
                 let length = self.device.read_u32(cap_next + 12);


### PR DESCRIPTION
This PR proposes updating Rust toolchain to nightly-2022-11-12. It also includes some fixes suggested by the new version of clippy.