### PR TITLE
bootinfo: Add architecture-independent memory entry

### DIFF
--- a/src/bootinfo.rs
+++ b/src/bootinfo.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022 Akira Moroo
+
+// Common data needed for all boot paths
+pub trait Info {
+    // Name of for this boot protocol
+    fn name(&self) -> &str;
+    // Starting address of the Root System Descriptor Pointer
+    fn rsdp_addr(&self) -> u64;
+    // The kernel command line (not including null terminator)
+    fn cmdline(&self) -> &[u8];
+    // Methods to access the Memory map
+    fn num_entries(&self) -> usize;
+    fn entry(&self, idx: usize) -> MemoryEntry;
+}
+
+pub struct MemoryEntry {
+    pub addr: u64,
+    pub size: u64,
+    pub entry_type: EntryType,
+}
+
+#[derive(PartialEq)]
+pub enum EntryType {
+    Ram,
+    Reserved,
+    AcpiReclaimable,
+    AcpiNvs,
+    Bad,
+    VendorReserved,
+    CorebootTable,
+}

--- a/src/bzimage.rs
+++ b/src/bzimage.rs
@@ -15,7 +15,8 @@ use atomic_refcell::AtomicRefCell;
 
 use crate::{
     block::SectorBuf,
-    boot::{E820Entry, Header, Info, Params},
+    boot::{Header, Params},
+    bootinfo::{EntryType, Info},
     fat::{self, Read},
     mem::MemoryRegion,
 };
@@ -95,7 +96,7 @@ impl Kernel {
         let mut current_addr = None;
         for i in 0..self.0.num_entries() {
             let entry = self.0.entry(i);
-            if entry.entry_type != E820Entry::RAM_TYPE {
+            if entry.entry_type != EntryType::Ram {
                 continue;
             }
 

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -14,7 +14,7 @@
 
 use crate::{
     block::SectorBuf,
-    boot,
+    bootinfo,
     bzimage::{self, Kernel},
     common::ascii_strip,
     fat::{self, Read},
@@ -217,7 +217,10 @@ fn default_entry_path(fs: &fat::Filesystem) -> Result<[u8; 260], Error> {
     Ok(entry_path)
 }
 
-pub fn load_default_entry(fs: &fat::Filesystem, info: &dyn boot::Info) -> Result<Kernel, Error> {
+pub fn load_default_entry(
+    fs: &fat::Filesystem,
+    info: &dyn bootinfo::Info,
+) -> Result<Kernel, Error> {
     let default_entry_path = default_entry_path(fs)?;
     let default_entry_path = ascii_strip(&default_entry_path);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ mod common;
 mod arch;
 mod block;
 mod boot;
+mod bootinfo;
 mod bzimage;
 #[cfg(target_arch = "x86_64")]
 mod cmos;
@@ -75,7 +76,7 @@ fn panic(_: &PanicInfo) -> ! {
 const VIRTIO_PCI_VENDOR_ID: u16 = 0x1af4;
 const VIRTIO_PCI_BLOCK_DEVICE_ID: u16 = 0x1042;
 
-fn boot_from_device(device: &mut block::VirtioBlockDevice, info: &dyn boot::Info) -> bool {
+fn boot_from_device(device: &mut block::VirtioBlockDevice, info: &dyn bootinfo::Info) -> bool {
     if let Err(err) = device.init() {
         log!("Error configuring block device: {:?}", err);
         return false;
@@ -153,7 +154,7 @@ pub extern "C" fn rust64_start(#[cfg(not(feature = "coreboot"))] pvh_info: &pvh:
 }
 
 #[cfg(target_arch = "x86_64")]
-fn main(info: &dyn boot::Info) -> ! {
+fn main(info: &dyn bootinfo::Info) -> ! {
     log!("\nBooting with {}", info.name());
 
     pci::print_bus();

--- a/src/pvh.rs
+++ b/src/pvh.rs
@@ -1,7 +1,7 @@
 use core::mem::size_of;
 
 use crate::{
-    boot::{E820Entry, Info},
+    bootinfo::{EntryType, Info, MemoryEntry},
     common,
 };
 
@@ -30,6 +30,16 @@ struct MemMapEntry {
     _pad: u32,
 }
 
+impl From<MemMapEntry> for MemoryEntry {
+    fn from(value: MemMapEntry) -> Self {
+        Self {
+            addr: value.addr,
+            size: value.size,
+            entry_type: EntryType::from(value.entry_type),
+        }
+    }
+}
+
 impl Info for StartInfo {
     fn name(&self) -> &str {
         "PVH Boot Protocol"
@@ -40,22 +50,18 @@ impl Info for StartInfo {
     fn cmdline(&self) -> &[u8] {
         unsafe { common::from_cstring(self.cmdline_paddr) }
     }
-    fn num_entries(&self) -> u8 {
+    fn num_entries(&self) -> usize {
         // memmap_paddr and memmap_entries only exist in version 1 or later
         if self.version < 1 || self.memmap_paddr == 0 {
             return 0;
         }
-        self.memmap_entries as u8
+        self.memmap_entries as usize
     }
-    fn entry(&self, idx: u8) -> E820Entry {
+    fn entry(&self, idx: usize) -> MemoryEntry {
         assert!(idx < self.num_entries());
         let ptr = self.memmap_paddr as *const MemMapEntry;
-        let entry = unsafe { *ptr.offset(idx as isize) };
-        E820Entry {
-            addr: entry.addr,
-            size: entry.size,
-            entry_type: entry.entry_type,
-        }
+        let entry = unsafe { *ptr.add(idx) };
+        MemoryEntry::from(entry)
     }
 }
 


### PR DESCRIPTION
`E820Entry` is used in `boot::Info` trait, which is x86_64-dependent memory entry data structure. It's confusing if e820 is used in other architectures. This commit introduces an architecture-independent memory entry `bootinfo::MemoryEntry` and replaces `boot::Info` with `bootinfo::Info`. This change is suggested in [1].

[1]
https://github.com/cloud-hypervisor/rust-hypervisor-firmware/pull/205#discussion_r1028921329

Signed-off-by: Akira Moroo <retrage01@gmail.com>