### PR TITLE
aarch64: Setup SIMD at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aarch64-cpu"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb711c57d60565ba8f6523eb371e6243639617d817b4df1ae09af250af1af411"
+dependencies = [
+ "tock-registers",
+]
+
+[[package]]
 name = "atomic_refcell"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,15 +55,6 @@ checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "cortex-a"
-version = "8.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8256fd5103e10027467cc7a97c9ff27fcc4547ea24864da0aff2e7aef6e18e28"
-dependencies = [
- "tock-registers",
 ]
 
 [[package]]
@@ -107,10 +107,10 @@ dependencies = [
 name = "hypervisor-fw"
 version = "0.4.2"
 dependencies = [
+ "aarch64-cpu",
  "atomic_refcell",
  "bitflags",
  "chrono",
- "cortex-a",
  "dirs",
  "fdt",
  "linked_list_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ linked_list_allocator = "0.10.4"
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 tock-registers = "0.8.1"
-cortex-a = "8.1.1"
+aarch64-cpu = "9.3.1"
 fdt = "0.1.4"
 chrono = { version = "0.4", default-features = false }
 

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -5,4 +5,5 @@
 pub mod asm;
 pub mod layout;
 pub mod paging;
+pub mod simd;
 mod translation;

--- a/src/arch/aarch64/paging.rs
+++ b/src/arch/aarch64/paging.rs
@@ -4,7 +4,7 @@
 
 use core::ops::RangeInclusive;
 
-use cortex_a::{asm::barrier, registers::*};
+use aarch64_cpu::{asm::barrier, registers::*};
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 
 use self::interface::Mmu;

--- a/src/arch/aarch64/simd.rs
+++ b/src/arch/aarch64/simd.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023 Akira Moroo
+
+use aarch64_cpu::registers::*;
+use tock_registers::interfaces::ReadWriteable;
+
+pub fn setup_simd() {
+    CPACR_EL1.modify(CPACR_EL1::FPEN::TrapNothing);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,6 +171,7 @@ pub extern "C" fn rust64_start(#[cfg(not(feature = "coreboot"))] pvh_info: &pvh:
 pub extern "C" fn rust64_start(x0: *const u8) -> ! {
     serial::PORT.borrow_mut().init();
 
+    arch::aarch64::simd::setup_simd();
     arch::aarch64::paging::setup();
 
     let info = fdt::StartInfo::new(x0);


### PR DESCRIPTION
These changes are required to run a recently built GRUB binary as described in the commit 89764cf4fa2498a5d08de4ec660d52c44dd39c73.