### PR TITLE
scripts: Bump Cloud Hypervisor version to v30.0

### DIFF
--- a/scripts/fetch_images.sh
+++ b/scripts/fetch_images.sh
@@ -3,7 +3,7 @@ set -x
 
 fetch_ch() {
     CH_PATH="$1"
-    CH_VERSION="v24.0"
+    CH_VERSION="v30.0"
     CH_URL="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/$CH_VERSION/cloud-hypervisor"
     if [ ! -f "$CH_PATH" ]; then
         wget --quiet $CH_URL -O $CH_PATH

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -494,6 +494,7 @@ mod tests {
                 "target/x86_64-unknown-none/release/hypervisor-fw",
                 "--disk",
                 &format!("path={os}"),
+                "--disk",
                 &format!("path={ci}"),
                 "--net",
                 &format!("tap={},mac={}", net.tap_name, net.guest_mac),


### PR DESCRIPTION
As Cloud Hypervisor v30.0 has been released, this PR bumps the target version to the latest.

NOTE: This PR should be merged after PR #219 is merged.