### PR TITLE
efi: Use a constant for the EFI boot path

### DIFF
--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -46,6 +46,10 @@ mod var;
 
 use alloc::Allocator;
 use var::VariableAllocator;
+#[cfg(target_arch = "aarch64")]
+pub const EFI_BOOT_PATH: &str = "\\EFI\\BOOT\\BOOTAA64.EFI";
+#[cfg(target_arch = "x86_64")]
+pub const EFI_BOOT_PATH: &str = "\\EFI\\BOOT\\BOOTX64.EFI";
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 enum HandleType {
@@ -1117,10 +1121,7 @@ pub fn efi_exec(
     let wrapped_fs = file::FileSystemWrapper::new(fs, efi_part_id);
 
     let image = new_image_handle(
-        #[cfg(target_arch = "aarch64")]
-        "\\EFI\\BOOT\\BOOTAA64.EFI",
-        #[cfg(target_arch = "x86_64")]
-        "\\EFI\\BOOT\\BOOTX64.EFI",
+        crate::efi::EFI_BOOT_PATH,
         0 as Handle,
         &wrapped_fs as *const _ as Handle,
         loaded_address,

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,18 +117,15 @@ fn boot_from_device(device: &mut block::VirtioBlockDevice, info: &dyn bootinfo::
     }
 
     log!("Using EFI boot.");
-    #[cfg(target_arch = "aarch64")]
-    let efi_boot_path = "/EFI/BOOT/BOOTAA64.EFI";
-    #[cfg(target_arch = "x86_64")]
-    let efi_boot_path = "/EFI/BOOT/BOOTX64 EFI";
-    let mut file = match f.open(efi_boot_path) {
+
+    let mut file = match f.open(efi::EFI_BOOT_PATH) {
         Ok(file) => file,
         Err(err) => {
             log!("Failed to load default EFI binary: {:?}", err);
             return false;
         }
     };
-    log!("Found bootloader: {}", efi_boot_path);
+    log!("Found bootloader: {}", efi::EFI_BOOT_PATH);
 
     let mut l = pe::Loader::new(&mut file);
     #[cfg(target_arch = "aarch64")]


### PR DESCRIPTION
Since the EFI ABI expects `\\` as the directory separator and our FAT
implementation accepts both then use that as the preferred version.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
