### PR TITLE
Increase portability though existing Info trait

### DIFF
--- a/src/arch/x86_64/layout.rs
+++ b/src/arch/x86_64/layout.rs
@@ -33,6 +33,8 @@ pub fn stack_range() -> Range<usize> {
 
 const NUM_MEM_DESCS: usize = 4;
 
+pub const KERNEL_START: u64 = 0x20_0000;
+
 pub static MEM_LAYOUT: MemoryLayout<NUM_MEM_DESCS> = [
     MemoryDescriptor {
         name: "PVH Header",

--- a/src/bootinfo.rs
+++ b/src/bootinfo.rs
@@ -6,7 +6,9 @@ pub trait Info {
     // Name of for this boot protocol
     fn name(&self) -> &str;
     // Starting address of the Root System Descriptor Pointer
-    fn rsdp_addr(&self) -> u64;
+    fn rsdp_addr(&self) -> Option<u64> {
+        None
+    }
     // The kernel command line (not including null terminator)
     fn cmdline(&self) -> &[u8];
     // Methods to access the Memory map

--- a/src/bootinfo.rs
+++ b/src/bootinfo.rs
@@ -18,6 +18,8 @@ pub trait Info {
     // Methods to access the Memory map
     fn num_entries(&self) -> usize;
     fn entry(&self, idx: usize) -> MemoryEntry;
+    // Where to load kernel
+    fn kernel_load_addr(&self) -> u64;
 }
 
 pub struct MemoryEntry {

--- a/src/bootinfo.rs
+++ b/src/bootinfo.rs
@@ -9,6 +9,10 @@ pub trait Info {
     fn rsdp_addr(&self) -> Option<u64> {
         None
     }
+    // Address of FDT to use for booting if present
+    fn fdt_addr(&self) -> Option<u64> {
+        None
+    }
     // The kernel command line (not including null terminator)
     fn cmdline(&self) -> &[u8];
     // Methods to access the Memory map

--- a/src/bootinfo.rs
+++ b/src/bootinfo.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2022 Akira Moroo
 
+use crate::layout::MemoryDescriptor;
+
 // Common data needed for all boot paths
 pub trait Info {
     // Name of for this boot protocol
@@ -20,6 +22,8 @@ pub trait Info {
     fn entry(&self, idx: usize) -> MemoryEntry;
     // Where to load kernel
     fn kernel_load_addr(&self) -> u64;
+    // Reference to memory layout
+    fn memory_layout(&self) -> &'static [MemoryDescriptor];
 }
 
 pub struct MemoryEntry {

--- a/src/bzimage.rs
+++ b/src/bzimage.rs
@@ -43,7 +43,7 @@ pub struct Kernel(Params);
 impl Kernel {
     pub fn new(info: &dyn Info) -> Self {
         let mut kernel = Self(Params::default());
-        kernel.0.acpi_rsdp_addr = info.rsdp_addr();
+        kernel.0.acpi_rsdp_addr = info.rsdp_addr().unwrap_or_default();
         kernel.0.set_entries(info);
         kernel
     }

--- a/src/coreboot.rs
+++ b/src/coreboot.rs
@@ -93,8 +93,8 @@ impl Info for StartInfo {
     fn name(&self) -> &str {
         "coreboot"
     }
-    fn rsdp_addr(&self) -> u64 {
-        self.rsdp_addr
+    fn rsdp_addr(&self) -> Option<u64> {
+        Some(self.rsdp_addr)
     }
     fn cmdline(&self) -> &[u8] {
         b""

--- a/src/coreboot.rs
+++ b/src/coreboot.rs
@@ -114,6 +114,9 @@ impl Info for StartInfo {
     fn kernel_load_addr(&self) -> u64 {
         crate::arch::x86_64::layout::KERNEL_START
     }
+    fn memory_layout(&self) -> &'static [crate::layout::MemoryDescriptor] {
+        &crate::arch::x86_64::layout::MEM_LAYOUT[..]
+    }
 }
 
 fn find_header(start: u64, len: usize) -> Option<u64> {

--- a/src/coreboot.rs
+++ b/src/coreboot.rs
@@ -111,6 +111,9 @@ impl Info for StartInfo {
         let entry = unsafe { &*ptr.add(idx) };
         MemoryEntry::from(*entry)
     }
+    fn kernel_load_addr(&self) -> u64 {
+        crate::arch::x86_64::layout::KERNEL_START
+    }
 }
 
 fn find_header(start: u64, len: usize) -> Option<u64> {

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -1072,9 +1072,8 @@ pub fn efi_exec(
     block: *const crate::block::VirtioBlockDevice,
 ) {
     let vendor_data = 0u32;
-    let acpi_rsdp_ptr = info.rsdp_addr();
 
-    let ct_entry = if acpi_rsdp_ptr != 0 {
+    let ct_entry = if let Some(acpi_rsdp_ptr) = info.rsdp_addr() {
         efi::ConfigurationTable {
             vendor_guid: Guid::from_fields(
                 0x8868_e871,

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -936,13 +936,7 @@ fn populate_allocator(info: &dyn bootinfo::Info, image_address: u64, image_size:
         }
     }
 
-    #[cfg(target_arch = "aarch64")]
-    use crate::arch::aarch64::layout::MEM_LAYOUT;
-
-    #[cfg(target_arch = "x86_64")]
-    use crate::arch::x86_64::layout::MEM_LAYOUT;
-
-    for descriptor in MEM_LAYOUT {
+    for descriptor in info.memory_layout() {
         let memory_type = match descriptor.attribute {
             layout::MemoryAttribute::Code => efi::RUNTIME_SERVICES_CODE,
             layout::MemoryAttribute::Data => efi::RUNTIME_SERVICES_DATA,

--- a/src/fdt.rs
+++ b/src/fdt.rs
@@ -9,10 +9,11 @@ pub struct StartInfo<'a> {
     acpi_rsdp_addr: Option<u64>,
     fdt_addr: u64,
     fdt: Fdt<'a>,
+    kernel_load_addr: u64,
 }
 
 impl StartInfo<'_> {
-    pub fn new(ptr: *const u8, acpi_rsdp_addr: Option<u64>) -> Self {
+    pub fn new(ptr: *const u8, acpi_rsdp_addr: Option<u64>, kernel_load_addr: u64) -> Self {
         let fdt = unsafe {
             match Fdt::from_ptr(ptr) {
                 Ok(fdt) => fdt,
@@ -26,6 +27,7 @@ impl StartInfo<'_> {
             fdt_addr,
             fdt,
             acpi_rsdp_addr,
+            kernel_load_addr,
         }
     }
 
@@ -73,5 +75,9 @@ impl Info for StartInfo<'_> {
             }
         }
         panic!("No valid memory entry found");
+    }
+
+    fn kernel_load_addr(&self) -> u64 {
+        self.kernel_load_addr
     }
 }

--- a/src/fdt.rs
+++ b/src/fdt.rs
@@ -3,17 +3,26 @@
 
 use fdt::Fdt;
 
-use crate::bootinfo::{EntryType, Info, MemoryEntry};
+use crate::{
+    bootinfo::{EntryType, Info, MemoryEntry},
+    layout::MemoryDescriptor,
+};
 
 pub struct StartInfo<'a> {
     acpi_rsdp_addr: Option<u64>,
     fdt_addr: u64,
     fdt: Fdt<'a>,
     kernel_load_addr: u64,
+    memory_layout: &'static [MemoryDescriptor],
 }
 
 impl StartInfo<'_> {
-    pub fn new(ptr: *const u8, acpi_rsdp_addr: Option<u64>, kernel_load_addr: u64) -> Self {
+    pub fn new(
+        ptr: *const u8,
+        acpi_rsdp_addr: Option<u64>,
+        kernel_load_addr: u64,
+        memory_layout: &'static [MemoryDescriptor],
+    ) -> Self {
         let fdt = unsafe {
             match Fdt::from_ptr(ptr) {
                 Ok(fdt) => fdt,
@@ -28,6 +37,7 @@ impl StartInfo<'_> {
             fdt,
             acpi_rsdp_addr,
             kernel_load_addr,
+            memory_layout,
         }
     }
 
@@ -79,5 +89,9 @@ impl Info for StartInfo<'_> {
 
     fn kernel_load_addr(&self) -> u64 {
         self.kernel_load_addr
+    }
+
+    fn memory_layout(&self) -> &'static [MemoryDescriptor] {
+        self.memory_layout
     }
 }

--- a/src/fdt.rs
+++ b/src/fdt.rs
@@ -7,6 +7,7 @@ use crate::bootinfo::{EntryType, Info, MemoryEntry};
 
 pub struct StartInfo<'a> {
     acpi_rsdp_addr: Option<u64>,
+    fdt_addr: u64,
     fdt: Fdt<'a>,
 }
 
@@ -19,7 +20,10 @@ impl StartInfo<'_> {
             }
         };
 
+        let fdt_addr = ptr as u64;
+
         Self {
+            fdt_addr,
             fdt,
             acpi_rsdp_addr,
         }
@@ -41,6 +45,10 @@ impl Info for StartInfo<'_> {
 
     fn rsdp_addr(&self) -> Option<u64> {
         self.acpi_rsdp_addr
+    }
+
+    fn fdt_addr(&self) -> Option<u64> {
+        Some(self.fdt_addr)
     }
 
     fn cmdline(&self) -> &[u8] {

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -237,7 +237,7 @@ pub fn load_default_entry(
     let mut kernel = Kernel::new(info);
 
     let mut bzimage_file = fs.open(bzimage_path)?;
-    kernel.load_kernel(&mut bzimage_file)?;
+    kernel.load_kernel(info, &mut bzimage_file)?;
 
     if !initrd_path.is_empty() {
         let mut initrd_file = fs.open(initrd_path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,11 +129,8 @@ fn boot_from_device(device: &mut block::VirtioBlockDevice, info: &dyn bootinfo::
     log!("Found bootloader: {}", efi::EFI_BOOT_PATH);
 
     let mut l = pe::Loader::new(&mut file);
-    #[cfg(target_arch = "aarch64")]
-    let load_addr = arch::aarch64::layout::map::dram::KERNEL_START as u64;
-    #[cfg(target_arch = "x86_64")]
-    let load_addr = 0x20_0000;
-    let (entry_addr, load_addr, size) = match l.load(load_addr) {
+
+    let (entry_addr, load_addr, size) = match l.load(info.kernel_load_addr()) {
         Ok(load_info) => load_info,
         Err(err) => {
             log!("Error loading executable: {:?}", err);
@@ -174,6 +171,7 @@ pub extern "C" fn rust64_start(x0: *const u8) -> ! {
     let info = fdt::StartInfo::new(
         x0,
         Some(arch::aarch64::layout::map::dram::ACPI_START as u64),
+        arch::aarch64::layout::map::dram::KERNEL_START as u64,
     );
 
     if let Some((base, length)) = info.find_compatible_region(&["pci-host-ecam-generic"]) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,10 @@ pub extern "C" fn rust64_start(x0: *const u8) -> ! {
     arch::aarch64::simd::setup_simd();
     arch::aarch64::paging::setup();
 
-    let info = fdt::StartInfo::new(x0);
+    let info = fdt::StartInfo::new(
+        x0,
+        Some(arch::aarch64::layout::map::dram::ACPI_START as u64),
+    );
 
     if let Some((base, length)) = info.find_compatible_region(&["pci-host-ecam-generic"]) {
         pci::init(base as u64, length as u64);

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ mod bootinfo;
 mod bzimage;
 #[cfg(target_arch = "x86_64")]
 mod cmos;
+#[cfg(target_arch = "x86_64")]
 mod coreboot;
 mod delay;
 mod efi;

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,6 +172,7 @@ pub extern "C" fn rust64_start(x0: *const u8) -> ! {
         x0,
         Some(arch::aarch64::layout::map::dram::ACPI_START as u64),
         arch::aarch64::layout::map::dram::KERNEL_START as u64,
+        &crate::arch::aarch64::layout::MEM_LAYOUT[..],
     );
 
     if let Some((base, length)) = info.find_compatible_region(&["pci-host-ecam-generic"]) {

--- a/src/pvh.rs
+++ b/src/pvh.rs
@@ -63,6 +63,9 @@ impl Info for StartInfo {
         let entry = unsafe { *ptr.add(idx) };
         MemoryEntry::from(entry)
     }
+    fn kernel_load_addr(&self) -> u64 {
+        crate::arch::x86_64::layout::KERNEL_START
+    }
 }
 
 // The PVH Boot Protocol starts at the 32-bit entrypoint to our firmware.

--- a/src/pvh.rs
+++ b/src/pvh.rs
@@ -3,6 +3,7 @@ use core::mem::size_of;
 use crate::{
     bootinfo::{EntryType, Info, MemoryEntry},
     common,
+    layout::MemoryDescriptor,
 };
 
 // Structures from xen/include/public/arch-x86/hvm/start_info.h
@@ -65,6 +66,9 @@ impl Info for StartInfo {
     }
     fn kernel_load_addr(&self) -> u64 {
         crate::arch::x86_64::layout::KERNEL_START
+    }
+    fn memory_layout(&self) -> &'static [MemoryDescriptor] {
+        &crate::arch::x86_64::layout::MEM_LAYOUT[..]
     }
 }
 

--- a/src/pvh.rs
+++ b/src/pvh.rs
@@ -44,8 +44,8 @@ impl Info for StartInfo {
     fn name(&self) -> &str {
         "PVH Boot Protocol"
     }
-    fn rsdp_addr(&self) -> u64 {
-        self.rsdp_paddr
+    fn rsdp_addr(&self) -> Option<u64> {
+        Some(self.rsdp_paddr)
     }
     fn cmdline(&self) -> &[u8] {
         unsafe { common::from_cstring(self.cmdline_paddr) }


### PR DESCRIPTION
- bootinfo: Use Option<u64> for address of RSDP
- coreboot: Make module inclusion architecture specific
- fdt: Make available the guest FDT table if necessary
- bootinfo: Reduce hardcoding of load address for kernel
- bootinfo: Include reference to memory layout
