### PR TITLE
Allocate PCI BARs where needed

### DIFF
--- a/src/bootinfo.rs
+++ b/src/bootinfo.rs
@@ -24,15 +24,20 @@ pub trait Info {
     fn kernel_load_addr(&self) -> u64;
     // Reference to memory layout
     fn memory_layout(&self) -> &'static [MemoryDescriptor];
+    // MMIO address space that can be used for PCI BARs if needed
+    fn pci_bar_memory(&self) -> Option<MemoryEntry> {
+        None
+    }
 }
 
+#[derive(Clone, Copy)]
 pub struct MemoryEntry {
     pub addr: u64,
     pub size: u64,
     pub entry_type: EntryType,
 }
 
-#[derive(PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum EntryType {
     Ram,
     Reserved,

--- a/src/fdt.rs
+++ b/src/fdt.rs
@@ -14,6 +14,7 @@ pub struct StartInfo<'a> {
     fdt: Fdt<'a>,
     kernel_load_addr: u64,
     memory_layout: &'static [MemoryDescriptor],
+    pci_bar_memory: Option<MemoryEntry>,
 }
 
 impl StartInfo<'_> {
@@ -22,6 +23,7 @@ impl StartInfo<'_> {
         acpi_rsdp_addr: Option<u64>,
         kernel_load_addr: u64,
         memory_layout: &'static [MemoryDescriptor],
+        pci_bar_memory: Option<MemoryEntry>,
     ) -> Self {
         let fdt = unsafe {
             match Fdt::from_ptr(ptr) {
@@ -38,6 +40,7 @@ impl StartInfo<'_> {
             acpi_rsdp_addr,
             kernel_load_addr,
             memory_layout,
+            pci_bar_memory,
         }
     }
 
@@ -93,5 +96,9 @@ impl Info for StartInfo<'_> {
 
     fn memory_layout(&self) -> &'static [MemoryDescriptor] {
         self.memory_layout
+    }
+
+    fn pci_bar_memory(&self) -> Option<MemoryEntry> {
+        self.pci_bar_memory
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,7 @@ pub extern "C" fn rust64_start(x0: *const u8) -> ! {
         Some(arch::aarch64::layout::map::dram::ACPI_START as u64),
         arch::aarch64::layout::map::dram::KERNEL_START as u64,
         &crate::arch::aarch64::layout::MEM_LAYOUT[..],
+        None,
     );
 
     if let Some((base, length)) = info.find_compatible_region(&["pci-host-ecam-generic"]) {


### PR DESCRIPTION
- bootinfo: Support specifying a region to allocate PCI BARs from
- pci: Allocate PCI BARs from advertised range
- fdt: Support adjusting Info::pci_bar_memory()
