### PR TITLE
build: Store container in ghcr vs DockerHub

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -10,6 +10,9 @@ on:
     paths:
       - resources/Dockerfile
       - rust-toolchain.toml
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   main:
@@ -28,12 +31,20 @@ jobs:
         id: get-toolchain
         run: echo "toolchain=`rustup show active-toolchain | cut -d ' ' -f1`" >> $GITHUB_ENV
 
-      - name: Login to DockerHub
-        if: ${{ github.repository == 'cloud-hypervisor/rust-hypervisor-firmware' && github.event_name == 'push' }}
+      - name: Login to ghcr
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=true
 
       - name: Build
         uses: docker/build-push-action@v3
@@ -44,8 +55,8 @@ jobs:
           platforms: |
             linux/arm64
             linux/amd64
-          push: ${{ github.repository == 'cloud-hypervisor/rust-hypervisor-firmware' && github.event_name == 'push' }}
-          tags: rusthypervisorfirmware/dev:latest
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 FROM ubuntu:22.04 as dev
 
 ARG TARGETARCH

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -6,7 +6,7 @@
 
 CLI_NAME="Rust Hypervisor Firmware"
 
-CTR_IMAGE_TAG="rusthypervisorfirmware/dev"
+CTR_IMAGE_TAG="ghcr.io/cloud-hypervisor/rust-hypervisor-firmware"
 CTR_IMAGE_VERSION="latest"
 CTR_IMAGE="${CTR_IMAGE_TAG}:${CTR_IMAGE_VERSION}"
 


### PR DESCRIPTION
The small team DockerHub account is going away so the logical place to
store the built container is in the GitHub container registry.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
