### PR TITLE
Linux EFI Stub fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
                                                 }
                                                 stage('Run unit tests') {
                                                           steps {
-                                                                  sh "scripts/dev_cli.sh --local tests --unit"
+                                                                  sh "scripts/dev_cli.sh tests --unit"
                                                           }
                                                 }
                                         }

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -166,10 +166,6 @@ ensure_latest_ctr() {
 
         $DOCKER_RUNTIME pull --platform "$PLATFORM" "$CTR_IMAGE"
 
-        if [ $? -ne 0 ]; then
-            build_container
-        fi
-
         ok_or_die "Error pulling container image. Aborting."
     fi
 }

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -924,7 +924,7 @@ fn extract_path(device_path: &DevicePathProtocol, path: &mut [u8]) {
 }
 
 const PAGE_SIZE: u64 = 4096;
-const HEAP_SIZE: usize = 256 * 1024 * 1024;
+const HEAP_SIZE: usize = 2 << 20; /* 2MiB */
 
 // Populate allocator from E820, fixed ranges for the firmware and the loaded binary.
 fn populate_allocator(info: &dyn bootinfo::Info, image_address: u64, image_size: u64) {

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -883,9 +883,13 @@ pub extern "efiapi" fn calculate_crc32(_: *mut c_void, _: usize, _: *mut u32) ->
     Status::UNSUPPORTED
 }
 
-pub extern "efiapi" fn copy_mem(_: *mut c_void, _: *mut c_void, _: usize) {}
+pub extern "efiapi" fn copy_mem(dst: *mut c_void, src: *mut c_void, count: usize) {
+    unsafe { core::ptr::copy(src as *const u8, dst as *mut u8, count) }
+}
 
-pub extern "efiapi" fn set_mem(_: *mut c_void, _: usize, _: u8) {}
+pub extern "efiapi" fn set_mem(dst: *mut c_void, count: usize, val: u8) {
+    unsafe { core::ptr::write_bytes(dst as *mut u8, val, count) }
+}
 
 pub extern "efiapi" fn create_event_ex(
     _: u32,

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -165,6 +165,9 @@ static mut CT: [efi::ConfigurationTable; MAX_CT_ENTRIES] = [efi::ConfigurationTa
     vendor_table: null_mut(),
 }; MAX_CT_ENTRIES];
 
+// RHF string in UCS-2
+const FIRMWARE_STRING: [u16; 4] = [0x0052, 0x0048, 0x0046, 0x0000];
+
 static mut ST: efi::SystemTable = efi::SystemTable {
     hdr: efi::TableHeader {
         signature: efi::SYSTEM_TABLE_SIGNATURE,
@@ -173,7 +176,7 @@ static mut ST: efi::SystemTable = efi::SystemTable {
         crc32: 0, // TODO
         reserved: 0,
     },
-    firmware_vendor: null_mut(), // TODO,
+    firmware_vendor: FIRMWARE_STRING.as_ptr() as *mut u16,
     firmware_revision: 0,
     console_in_handle: console::STDIN_HANDLE,
     con_in: null_mut(),


### PR DESCRIPTION
Here are some fixes I needed to make for enabling booting Linux using the EFI
Stub support.

- efi: Include a firmware vendor string
- efi: Populate CopyMem/SetMem EFI functions
- efi: Make the heap size more reasonable
