### PR TITLE
pci: Handle overflow on 32-bit PCI BAR calculation

### DIFF
--- a/src/pci.rs
+++ b/src/pci.rs
@@ -295,7 +295,7 @@ impl PciDevice {
                     panic!("I/O BARs are not supported on this platform");
                 }
             } else {
-                // bits 2-1 are the type 0 is 32-but, 2 is 64 bit
+                // bits 2-1 are the type 0 is 32-bit, 2 is 64 bit
                 match bar >> 1 & 3 {
                     0 => {
                         self.bars[current_bar].bar_type = PciBarType::MemorySpace32;

--- a/src/pci.rs
+++ b/src/pci.rs
@@ -302,7 +302,9 @@ impl PciDevice {
                         self.bars[current_bar].address = u64::from(bar & 0xffff_fff0);
 
                         self.write_u32(current_bar_offset, 0xffff_ffff);
-                        let size = !(self.read_u32(current_bar_offset) & 0xffff_fff0) + 1;
+                        let size = (!(self.read_u32(current_bar_offset) & 0xffff_fff0))
+                            .checked_add(1)
+                            .unwrap_or(0);
                         self.bars[current_bar].size = u64::from(size);
                         self.write_u32(current_bar_offset, bar);
                     }


### PR DESCRIPTION
Rust Hypervisor Firmware panics on the overflow with debug build on x86_64.

This PR proposes:
* 7ff9dea1064d09b52cebc2ab0d3f7acb1a454e22: Fix typo
* 62558d16ee4f35a06dd7bdf947655761590aad0d: Handle overflow on 32-bit PCI BAR size calculation