### PR TITLE
dev_cli.sh: Fix kvm directory path of the build command

### DIFF
--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -235,7 +235,7 @@ cmd_build() {
     arch="$(uname -m)"
     build="debug"
     features_build=""
-    exported_device="dev/kvm"
+    exported_device="/dev/kvm"
     while [ $# -gt 0 ]; do
 	case "$1" in
             "-h"|"--help")  { cmd_help; exit 1; } ;;


### PR DESCRIPTION
Current local variable `exported_device` under `cmd_build()` misses the root directory in the beginning, which will lead to the error of:

```
docker: Error response from daemon: OCI runtime create failed:
invalid mount {Destination:dev/kvm Type:bind
[...]
Options:[rbind]}: mount destination dev/kvm not absolute: unknown.
```
when running `scripts/dev_cli.sh build` command.

Fix the path by following the `cmd_test()`.