### PR TITLE
AArch64: speed up paging and fix exception caused by atomic operation

### DIFF
--- a/aarch64-unknown-none.ld
+++ b/aarch64-unknown-none.ld
@@ -18,7 +18,7 @@ SECTIONS
   code_start = .;
   .text.boot  : { *(.text.boot)        }
   .text       : { *(.text .text.*)     }
-  . = ALIGN(4K);
+  . = ALIGN(64K);
   code_end = .;
 
   data_start = .;

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,10 +168,11 @@ pub extern "C" fn rust64_start(#[cfg(not(feature = "coreboot"))] pvh_info: &pvh:
 #[cfg(target_arch = "aarch64")]
 #[no_mangle]
 pub extern "C" fn rust64_start(x0: *const u8) -> ! {
-    serial::PORT.borrow_mut().init();
-
     arch::aarch64::simd::setup_simd();
     arch::aarch64::paging::setup();
+
+    // Use atomic operation before MMU enabled may cause exception, see https://www.ipshop.xyz/5909.html
+    serial::PORT.borrow_mut().init();
 
     let info = fdt::StartInfo::new(
         x0,


### PR DESCRIPTION
There are some issues for rust firmware on arm64:

Two of them:

- use atomic instruction before mmu enabled may cause exception;
- page table creation takes too long;

To address above issues:

- Use atomic operation after MMU enabled;
- optimize page table creation algorithem;