### PR TITLE
misc: Clean up license notices and copyrights

### DIFF
--- a/src/arch/x86_64/asm.rs
+++ b/src/arch/x86_64/asm.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 Google LLC
+
 use core::arch::global_asm;
 
 global_asm!(include_str!("ram32.s"), options(att_syntax, raw));

--- a/src/arch/x86_64/gdt.rs
+++ b/src/arch/x86_64/gdt.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 Google LLC
+
 use core::mem::size_of;
 
 bitflags::bitflags! {

--- a/src/arch/x86_64/paging.rs
+++ b/src/arch/x86_64/paging.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 Google LLC
+
 use x86_64::{
     registers::control::Cr3,
     structures::paging::{PageSize, PageTable, PageTableFlags, PhysFrame, Size2MiB},

--- a/src/arch/x86_64/ram32.s
+++ b/src/arch/x86_64/ram32.s
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Google LLC
+
 .section .text32, "ax"
 .global ram32_start
 .code32

--- a/src/arch/x86_64/sse.rs
+++ b/src/arch/x86_64/sse.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 Google LLC
+
 use x86_64::registers::control::{Cr0, Cr0Flags, Cr4, Cr4Flags};
 
 // Enable SSE2 for XMM registers (needed for EFI calling)

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,16 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use core::cell::RefCell;
 

--- a/src/bzimage.rs
+++ b/src/bzimage.rs
@@ -1,16 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+
 use atomic_refcell::AtomicRefCell;
 
 use crate::{

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,16 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 #[macro_export]
 macro_rules! offset_of {

--- a/src/efi/alloc.rs
+++ b/src/efi/alloc.rs
@@ -1,16 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use r_efi::efi::{self, AllocateType, MemoryType, PhysicalAddress, Status, VirtualAddress};
 

--- a/src/efi/block.rs
+++ b/src/efi/block.rs
@@ -1,16 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use core::ffi::c_void;
 

--- a/src/efi/console.rs
+++ b/src/efi/console.rs
@@ -1,16 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use r_efi::{
     efi::{Boolean, Char16, Event, Handle, Status},

--- a/src/efi/file.rs
+++ b/src/efi/file.rs
@@ -1,16 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use core::ffi::c_void;
 

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -1,16 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use core::{
     alloc as heap_alloc,

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -1,16 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use crate::{
     block::{Error as BlockError, SectorBuf, SectorRead},

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1,16 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2020 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 // Integration tests live in this file. We can't use the Rust "integration test" mode
 // as we don't have the expected source code structure.

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,16 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use crate::{
     block::SectorBuf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 #![feature(asm_const)]
 #![feature(alloc_error_handler)]

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -1,16 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 #![allow(dead_code)]
 

--- a/src/part.rs
+++ b/src/part.rs
@@ -1,16 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use crate::block::{Error as BlockError, SectorBuf, SectorRead};
 

--- a/src/pci.rs
+++ b/src/pci.rs
@@ -1,16 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use atomic_refcell::AtomicRefCell;
 

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -1,16 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use crate::{block::SectorBuf, mem::MemoryRegion};
 

--- a/src/pvh.rs
+++ b/src/pvh.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 Google LLC
+
 use core::mem::size_of;
 
 use crate::{

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,16 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 // Inspired by https://github.com/phil-opp/blog_os/blob/post-03/src/vga_buffer.rs
 // from Philipp Oppermann

--- a/src/virtio.rs
+++ b/src/virtio.rs
@@ -1,16 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 /// Virtio related errors
 #[derive(Debug)]


### PR DESCRIPTION
This PR proposes:

* Replace Apache license texts with SPDX license identifiers.
* Add missing license and copyright notices.

Some of the code files originally written by @josephlr do not have copyright notices. I'd like to confirm this with him, as I'm not sure if these contributions were made as Google or individually.