### PR TITLE
Serial/AArch64: treat LF as LF + CR

### DIFF
--- a/src/uart_pl011.rs
+++ b/src/uart_pl011.rs
@@ -26,6 +26,10 @@ impl Pl011 {
 impl fmt::Write for Pl011 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         for byte in s.bytes() {
+            // Unix-like OS treats LF as CRLF
+            if byte == b'\n' {
+                self.send(b'\r');
+            }
             self.send(byte);
         }
         Ok(())


### PR DESCRIPTION
In current implementation of pl011, LF is just as LF. It is not the rule in Unix-like world which treats LF as CRLF.

See related linux kernel doc [1]

[1] https://www.kernel.org/doc/Documentation/serial/driver

Fixes: #258