### PR TITLE
AArch64: let ubuntu 20.04+ boot from rust hypervisor firmware

### DIFF
--- a/aarch64-unknown-none.ld
+++ b/aarch64-unknown-none.ld
@@ -4,9 +4,17 @@ ENTRY(ram64_start)
     DRAM:   [0x4000_0000-0xfc00_0000]
     FDT:    [0x4000_0000-0x401f_ffff)
     ACPI:   [0x4020_0000-0x403f_ffff)
-    kernel: [0x4048_0000-]
-   The stack start is at the end of the DRAM region. */
-ram_min = 0x40480000;
+    payload:[0x4040_0000-0x405f_ffff)
+    RHF:    [0x40600000-]
+   Assuming 2MB is enough to load payload.
+   The stack start is at the end of the RHF region. */
+ram_min = 0x40600000;
+
+/* This value must be identical with arch::aarch64::layout::map::dram::KERNEL_START. */
+PAYLOAD_START = 0x40400000;
+
+efi_image_size = rhf_end - ram_min;
+efi_image_offset = ram_min - PAYLOAD_START;
 
 SECTIONS
 {
@@ -41,4 +49,7 @@ SECTIONS
     *(.symtab)
     *(.strtab)
   }
+
+  . = ALIGN(4K);
+  rhf_end = .;
 }

--- a/src/arch/aarch64/ram64.s
+++ b/src/arch/aarch64/ram64.s
@@ -3,6 +3,8 @@
 
 .section .text.boot, "ax"
 .global ram64_start
+.global efi_image_size
+.global efi_image_offset
 
 ram64_start:
   /*
@@ -11,18 +13,18 @@ ram64_start:
    *
    * [1] https://docs.kernel.org/arm64/booting.html#call-the-kernel-image
    */
-  add x13, x18, #0x16   /* code0: UEFI "MZ" signature magic instruction */
-  b jump_to_rust        /* code1 */
+  add x13, x18, #0x16     /* code0: UEFI "MZ" signature magic instruction */
+  b jump_to_rust          /* code1 */
 
-  .quad 0               /* text_offset */
-  .quad 0               /* image_size */
-  .quad 0               /* flags */
-  .quad 0               /* res2 */
-  .quad 0               /* res3 */
-  .quad 0               /* res4 */
+  .quad efi_image_offset	/* text_offset */
+  .quad efi_image_size    /* image_size */
+  .quad 0                 /* flags */
+  .quad 0                 /* res2 */
+  .quad 0                 /* res3 */
+  .quad 0                 /* res4 */
 
-  .long 0x644d5241      /* "ARM\x64" magic number */
-  .long 0               /* res5 */
+  .long 0x644d5241        /* "ARM\x64" magic number */
+  .long 0                 /* res5 */
   .align 3
 
 jump_to_rust:

--- a/src/efi/alloc.rs
+++ b/src/efi/alloc.rs
@@ -23,7 +23,7 @@ struct Allocation {
     descriptor: MemoryDescriptor,
 }
 
-const MAX_ALLOCATIONS: usize = 256;
+const MAX_ALLOCATIONS: usize = 512;
 
 #[derive(Copy, Clone)]
 pub struct Allocator {

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -1115,6 +1115,9 @@ pub fn efi_exec(
     let mut ct_index = 0;
 
     // Populate with FDT table if present
+    // To ensure ACPI is used during boot do not include FDT table on aarch64
+    // https://github.com/torvalds/linux/blob/d528014517f2b0531862c02865b9d4c908019dc4/arch/arm64/kernel/acpi.c#L203
+    #[cfg(not(target_arch = "aarch64"))]
     if let Some(fdt_entry) = info.fdt_reservation() {
         ct[ct_index] = efi::ConfigurationTable {
             vendor_guid: Guid::from_fields(

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -614,7 +614,6 @@ pub extern "efiapi" fn install_configuration_table(guid: *mut Guid, table: *mut 
 
     for entry in ct.iter_mut() {
         if entry.vendor_guid == unsafe { *guid } {
-            entry.vendor_table = table;
             if table.is_null() {
                 entry.vendor_guid = INVALID_GUID;
                 entry.vendor_table = null_mut();

--- a/src/fat.rs
+++ b/src/fat.rs
@@ -232,6 +232,17 @@ fn name_to_str(input: &str, output: &mut [u8]) {
             break;
         }
     }
+
+    // If name is exactly 11 characters long then ensure separator is correctly added
+    if (output[10] >= b'a' && output[10] <= b'z' || output[10] >= b'A' && output[10] <= b'Z')
+        && output[7] != b' '
+        && output[7] != b'.'
+    {
+        output[11] = output[10];
+        output[10] = output[9];
+        output[9] = output[8];
+        output[8] = b'.';
+    }
 }
 
 impl<'a> Read for Node<'a> {
@@ -403,9 +414,9 @@ impl<'a> Directory<'a> {
         }
     }
 
-    pub fn next_node(&mut self) -> Result<(Node, [u8; 11]), Error> {
+    pub fn next_node(&mut self) -> Result<(Node, [u8; 12]), Error> {
         let de = self.next_entry()?;
-        let mut name = [0_u8; 11];
+        let mut name = [0_u8; 12];
         name_to_str(core::str::from_utf8(&de.name).unwrap(), &mut name);
 
         match de.file_type {
@@ -1172,17 +1183,17 @@ mod tests {
 
     #[test]
     fn test_name_to_str() {
-        let mut s = [0_u8; 11];
+        let mut s = [0_u8; 12];
         super::name_to_str("X       ABC", &mut s);
         assert_eq!(crate::common::ascii_strip(&s), "X.ABC");
-        let mut s = [0_u8; 11];
+        let mut s = [0_u8; 12];
         super::name_to_str(".", &mut s);
         assert_eq!(crate::common::ascii_strip(&s), ".");
-        let mut s = [0_u8; 11];
+        let mut s = [0_u8; 12];
         super::name_to_str("..", &mut s);
         assert_eq!(crate::common::ascii_strip(&s), "..");
-        let mut s = [0_u8; 11];
+        let mut s = [0_u8; 12];
         super::name_to_str("ABCDEFGHIJK", &mut s);
-        assert_eq!(crate::common::ascii_strip(&s), "ABCDEFGHIJK");
+        assert_eq!(crate::common::ascii_strip(&s), "ABCDEFGH.IJK");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,9 @@ use core::panic::PanicInfo;
 #[cfg(target_arch = "x86_64")]
 use x86_64::instructions::hlt;
 
+#[cfg(target_arch = "aarch64")]
+use crate::arch::aarch64::layout::code_range;
+
 #[macro_use]
 mod serial;
 
@@ -131,6 +134,12 @@ fn boot_from_device(device: &mut block::VirtioBlockDevice, info: &dyn bootinfo::
             return false;
         }
     };
+
+    #[cfg(target_arch = "aarch64")]
+    if code_range().start < (info.kernel_load_addr() + size) as usize {
+        log!("Error Boot Image is too large");
+        return false;
+    }
 
     log!("Executable loaded");
     efi::efi_exec(entry_addr, load_addr, size, info, &f, device);


### PR DESCRIPTION
There are several issues block ubuntu 20.04+ boot from rust hypervisor firmware:

1. Grub or UEFI Shim may large enough and overlaps the firmware code region;
2. UEFI Shim or Grub file name length longer than 11 can't be expressed correctly: for example: "BOOTAA64.CSV" will be carried as "BOOTAA64CSV" in rust hypervisor firmware;
3. EFI memory allocations can be ran out;
4. Pass full fdt to OS blocks ACPI initialization;

This PR try to fix them one by one:
1. Move code start address upward to enlarge the memory region used for loading Grub/Shim;
2. Fixup fat file name if needed;
3. Bump allocations max number;
4. Don't pass fdt in system configuration table;

After above fix, ubuntu 20.04+ can boot from rust hypervisor firmware. Test pass for ubuntu 18.04, 20.04 and 22.04.

Fixes: #261 