### PR TITLE
build: Bump tempfile from 3.6.0 to 3.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,12 +113,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.6.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
-dependencies = [
- "instant",
-]
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "fdt"
@@ -136,12 +133,6 @@ dependencies = [
  "libc",
  "wasi",
 ]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hypervisor-fw"
@@ -173,21 +164,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libssh2-sys"
@@ -226,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
@@ -380,13 +360,12 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
  "windows-sys",
@@ -433,11 +412,10 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
 dependencies = [
- "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,4 +49,4 @@ fdt = "0.1.5"
 dirs = "5.0.1"
 rand = "0.8.5"
 ssh2 = { version = "0.9.4", features = ["vendored-openssl"] }
-tempfile = "3.6.0"
+tempfile = "3.7.0"

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright © 2019 Intel Corporation
 
+#[cfg(all(not(test), not(feature = "integration_tests")))]
+use core::alloc as heap_alloc;
+
 use core::{
-    alloc as heap_alloc,
     ffi::c_void,
     mem::{size_of, transmute},
     ptr::null_mut,
@@ -65,7 +67,7 @@ pub static ALLOCATOR: AtomicRefCell<Allocator> = AtomicRefCell::new(Allocator::n
 #[global_allocator]
 pub static HEAP_ALLOCATOR: LockedHeap = LockedHeap::empty();
 
-#[cfg(not(test))]
+#[cfg(all(not(test), not(feature = "integration_tests")))]
 #[alloc_error_handler]
 fn heap_alloc_error_handler(layout: heap_alloc::Layout) -> ! {
     panic!("heap allocation error: {:?}", layout);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,18 +2,27 @@
 // Copyright © 2019 Intel Corporation
 
 #![feature(asm_const)]
-#![feature(alloc_error_handler)]
 #![feature(slice_take)]
 #![feature(stdsimd)]
 #![feature(stmt_expr_attributes)]
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]
+#![cfg_attr(
+    all(not(test), not(feature = "integration_tests")),
+    feature(alloc_error_handler)
+)]
 #![cfg_attr(test, allow(unused_imports, dead_code))]
 #![cfg_attr(not(feature = "log-serial"), allow(unused_variables, unused_imports))]
 
+#[cfg(all(not(test), not(feature = "integration_tests")))]
 use core::panic::PanicInfo;
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(
+    not(test),
+    not(feature = "integration_tests"),
+    target_arch = "x86_64",
+    feature = "log-panic"
+))]
 use x86_64::instructions::hlt;
 
 #[cfg(target_arch = "aarch64")]
@@ -60,7 +69,7 @@ mod uart_mmio;
 mod uart_pl011;
 mod virtio;
 
-#[cfg(all(not(test), feature = "log-panic"))]
+#[cfg(all(not(test), not(feature = "integration_tests"), feature = "log-panic"))]
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     log!("PANIC: {}", info);
@@ -70,7 +79,11 @@ fn panic(info: &PanicInfo) -> ! {
     }
 }
 
-#[cfg(all(not(test), not(feature = "log-panic")))]
+#[cfg(all(
+    not(test),
+    not(feature = "integration_tests"),
+    not(feature = "log-panic")
+))]
 #[panic_handler]
 fn panic(_: &PanicInfo) -> ! {
     loop {}


### PR DESCRIPTION
The PR #264 Clippy CI check is failing due to the conflicts with dependency crates. This PR includes a fix commit.