### PR TITLE
tests: Add integration tests for aarch64

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
                                                 }
                                         }
                                 }
-                                stage ('AArch64 Unit Tests') {
+                                stage ('AArch64 Tests') {
                                         agent { node { label 'focal-arm64' } }
                                         stages {
                                                 stage ('Checkout') {
@@ -73,6 +73,14 @@ pipeline {
                                                 stage('Run unit tests') {
                                                           steps {
                                                                   sh "scripts/dev_cli.sh tests --unit"
+                                                          }
+                                                }
+                                                stage('Run integration tests') {
+                                                          options {
+                                                                  timeout(time: 1, unit: 'HOURS')
+                                                          }
+                                                          steps {
+                                                                  sh "scripts/dev_cli.sh tests --integration"
                                                           }
                                                 }
                                         }

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -317,7 +317,7 @@ cmd_tests() {
                 shift
                 arg_vols="$1"
                 ;;
-            "--all")                 { cargo=true; unit=true;  [ "$arch" = "x86_64" ] && integration=true; } ;;
+            "--all")                 { cargo=true; unit=true; integration=true; } ;;
             "--")                    { shift; break; } ;;
             *)
 		die "Unknown tests argument: $1. Please use --help for help."
@@ -326,10 +326,7 @@ cmd_tests() {
 	shift
     done
 
-    if [ "$(uname -m)" = "aarch64" ] ; then
-        if [ "$integration" = true ] ; then
-            die "Integration test is not supported for aarch64."
-        fi
+    if [ "$arch" = "aarch64" ] ; then
         if [ "$integration_coreboot" = true ] ; then
             die "coreboot integration test is not supported for aarch64."
         fi

--- a/scripts/fetch_images.sh
+++ b/scripts/fetch_images.sh
@@ -7,6 +7,7 @@ fetch_ch() {
     CH_VERSION="v32.0"
     CH_URL_BASE="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/$CH_VERSION"
 
+    [ "$CH_ARCH" = "aarch64" ] && CH_NAME="cloud-hypervisor-static-aarch64"
     [ "$CH_ARCH" = "x86_64" ] && CH_NAME="cloud-hypervisor"
     CH_URL="$CH_URL_BASE/$CH_NAME"
 
@@ -46,6 +47,11 @@ fetch_raw_ubuntu_image() {
     convert_image "$OS_IMAGE_NAME" "$OS_RAW_IMAGE_NAME"
 }
 
+aarch64_fetch_disk_images() {
+    fetch_raw_ubuntu_image "focal" "arm64"
+    fetch_raw_ubuntu_image "jammy" "arm64"
+}
+
 x86_64_fetch_disk_images() {
     CLEAR_OS_IMAGE_NAME="clear-31311-cloudguest.img"
     CLEAR_OS_URL_BASE="https://cloud-hypervisor.azureedge.net/"
@@ -62,6 +68,7 @@ fetch_disk_images() {
 
     pushd "$WORKLOADS_DIR"
 
+    [ "$ARCH" = "aarch64" ] && aarch64_fetch_disk_images
     [ "$ARCH" = "x86_64" ] && x86_64_fetch_disk_images
 
     popd

--- a/scripts/run_coreboot_integration_tests.sh
+++ b/scripts/run_coreboot_integration_tests.sh
@@ -22,4 +22,4 @@ make -C $COREBOOT_DIR olddefconfig
 make -C $COREBOOT_DIR -j"$(nproc)"
 
 export RUST_BACKTRACE=1
-cargo test --features "coreboot integration_tests" "integration::tests::linux"
+cargo test --features "coreboot integration_tests" "integration::tests::linux::x86_64"

--- a/scripts/run_coreboot_integration_tests.sh
+++ b/scripts/run_coreboot_integration_tests.sh
@@ -6,15 +6,19 @@ RHF_ROOT_DIR=$(cd "$(dirname "$0")/../" && pwd)
 source "${CARGO_HOME:-$HOME/.cargo}/env"
 source "$(dirnam "$0")/fetch_images.sh"
 
+arch="$(uname -m)"
+
 WORKLOADS_DIR="$HOME/workloads"
 mkdir -p "$WORKLOADS_DIR"
 
-fetch_disk_images "$WORKLOADS_DIR"
+fetch_disk_images "$WORKLOADS_DIR" "$arch"
+
+[ "$arch" = "x86_64" ] && target="x86_64-unknown-none"
 
 rustup component add rust-src
-cargo build --release --target x86_64-unknown-none.json -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem --features "coreboot"
+cargo build --release --target "$target.json" -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem --features "coreboot"
 
-RHF_BIN="$RHF_ROOT_DIR/target/x86_64-unknown-none/release/hypervisor-fw"
+RHF_BIN="$RHF_ROOT_DIR/target/$target/release/hypervisor-fw"
 COREBOOT_CONFIG_IN="$RHF_ROOT_DIR/resources/coreboot/qemu-q35-config.in"
 
 cat $COREBOOT_CONFIG_IN | sed -e "s#@CONFIG_PAYLOAD_FILE@#$RHF_BIN#g" > "$COREBOOT_DIR/.config"
@@ -22,4 +26,4 @@ make -C $COREBOOT_DIR olddefconfig
 make -C $COREBOOT_DIR -j"$(nproc)"
 
 export RUST_BACKTRACE=1
-cargo test --features "coreboot integration_tests" "integration::tests::linux::x86_64"
+cargo test --features "coreboot integration_tests" "integration::tests::linux::$arch"

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -14,6 +14,7 @@ fetch_ch "$CH_PATH" "$arch"
 
 fetch_disk_images "$WORKLOADS_DIR" "$arch"
 
+[ "$arch" = "aarch64" ] && target="aarch64-unknown-none"
 [ "$arch" = "x86_64" ] && target="x86_64-unknown-none"
 
 rustup component add rust-src

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -16,4 +16,4 @@ rustup component add rust-src
 cargo build --release --target x86_64-unknown-none.json -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
 
 export RUST_BACKTRACE=1
-time cargo test --features "integration_tests" "integration::tests::linux"
+time cargo test --features "integration_tests" "integration::tests::linux::x86_64"

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -4,16 +4,20 @@ set -x
 source "${CARGO_HOME:-$HOME/.cargo}/env"
 source "$(dirname "$0")/fetch_images.sh"
 
+arch="$(uname -m)"
+
 WORKLOADS_DIR="$HOME/workloads"
 mkdir -p "$WORKLOADS_DIR"
 
 CH_PATH="$WORKLOADS_DIR/cloud-hypervisor"
-fetch_ch "$CH_PATH"
+fetch_ch "$CH_PATH" "$arch"
 
-fetch_disk_images "$WORKLOADS_DIR"
+fetch_disk_images "$WORKLOADS_DIR" "$arch"
+
+[ "$arch" = "x86_64" ] && target="x86_64-unknown-none"
 
 rustup component add rust-src
-cargo build --release --target x86_64-unknown-none.json -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
+cargo build --release --target "$target.json" -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
 
 export RUST_BACKTRACE=1
-time cargo test --features "integration_tests" "integration::tests::linux::x86_64"
+time cargo test --features "integration_tests" "integration::tests::linux::$arch"

--- a/scripts/run_integration_tests_windows.sh
+++ b/scripts/run_integration_tests_windows.sh
@@ -30,7 +30,7 @@ rustup component add rust-src
 cargo build --release --target x86_64-unknown-none.json -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
 
 export RUST_BACKTRACE=1
-time cargo test --features "integration_tests" "integration::tests::windows"
+time cargo test --features "integration_tests" "integration::tests::windows::x86_64"
 RES=$?
 
 dmsetup remove_all -f

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -465,6 +465,12 @@ mod tests {
         path: &'a str,
     }
 
+    #[cfg(target_arch = "x86_64")]
+    const TARGET_TRIPLE: &str = "x86_64-unknown-none";
+
+    #[cfg(target_arch = "x86_64")]
+    const QEMU_NAME: &str = "qemu-system-x86_64";
+
     mod linux {
         use crate::integration::tests::*;
 
@@ -480,7 +486,7 @@ mod tests {
                 "--serial",
                 "tty",
                 "--kernel",
-                "target/x86_64-unknown-none/release/hypervisor-fw",
+                &format!("target/{TARGET_TRIPLE}/release/hypervisor-fw"),
                 "--disk",
                 &format!("path={os}"),
                 "--disk",
@@ -506,7 +512,7 @@ mod tests {
             ci: &str,
             net: &GuestNetworkConfig,
         ) -> Child {
-            let mut c = Command::new("qemu-system-x86_64");
+            let mut c = Command::new(QEMU_NAME);
             c.args([
                 "-machine",
                 "q35,accel=kvm",
@@ -550,9 +556,10 @@ mod tests {
 
         #[cfg(not(feature = "coreboot"))]
         fn spawn_qemu(tmp_dir: &TempDir, os: &str, ci: &str, net: &GuestNetworkConfig) -> Child {
+            let path = format!("target/{TARGET_TRIPLE}/release/hypervisor-fw");
             let fw = Firmware {
                 fw_type: "-kernel",
-                path: "target/x86_64-unknown-none/release/hypervisor-fw",
+                path: path.as_str(),
             };
             spawn_qemu_common(tmp_dir, &fw, os, ci, net)
         }
@@ -660,7 +667,7 @@ mod tests {
 
             prepare_tap(&net);
 
-            let mut c = Command::new("qemu-system-x86_64");
+            let mut c = Command::new(QEMU_NAME);
             c.args([
                 "-machine",
                 "q35,accel=kvm",
@@ -720,9 +727,10 @@ mod tests {
             #[ignore] // Windows guest test on QEMU is not supported yet.
             #[cfg(not(feature = "coreboot"))]
             fn test_boot_qemu_windows() {
+                let path = format!("target/{TARGET_TRIPLE}/release/hypervisor-fw");
                 let fw = Firmware {
                     fw_type: "-kernel",
-                    path: "target/x86_64-unknown-none/release/hypervisor-fw",
+                    path: path.as_str(),
                 };
                 test_boot_qemu_windows_common(&fw);
             }
@@ -761,7 +769,7 @@ mod tests {
                     "--serial",
                     "tty",
                     "--kernel",
-                    "target/x86_64-unknown-none/release/hypervisor-fw",
+                    &format!("target/{TARGET_TRIPLE}/release/hypervisor-fw"),
                     "--disk",
                     &format!("path={}", disk.osdisk_path),
                     "--net",

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -598,41 +598,45 @@ mod tests {
             handle_child_output(&tmp_dir, r, &output);
         }
 
-        const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-amd64-raw.img";
-        const JAMMY_IMAGE_NAME: &str = "jammy-server-cloudimg-amd64-raw.img";
-        const CLEAR_IMAGE_NAME: &str = "clear-31311-cloudguest.img";
+        mod x86_64 {
+            use super::*;
 
-        #[test]
-        fn test_boot_qemu_focal() {
-            test_boot(FOCAL_IMAGE_NAME, &UbuntuCloudInit {}, spawn_qemu)
-        }
+            const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-amd64-raw.img";
+            const JAMMY_IMAGE_NAME: &str = "jammy-server-cloudimg-amd64-raw.img";
+            const CLEAR_IMAGE_NAME: &str = "clear-31311-cloudguest.img";
 
-        #[test]
-        fn test_boot_qemu_jammy() {
-            test_boot(JAMMY_IMAGE_NAME, &UbuntuCloudInit {}, spawn_qemu)
-        }
+            #[test]
+            fn test_boot_qemu_focal() {
+                test_boot(FOCAL_IMAGE_NAME, &UbuntuCloudInit {}, spawn_qemu)
+            }
 
-        #[test]
-        fn test_boot_qemu_clear() {
-            test_boot(CLEAR_IMAGE_NAME, &ClearCloudInit {}, spawn_qemu)
-        }
+            #[test]
+            fn test_boot_qemu_jammy() {
+                test_boot(JAMMY_IMAGE_NAME, &UbuntuCloudInit {}, spawn_qemu)
+            }
 
-        #[test]
-        #[cfg(not(feature = "coreboot"))]
-        fn test_boot_ch_focal() {
-            test_boot(FOCAL_IMAGE_NAME, &UbuntuCloudInit {}, spawn_ch)
-        }
+            #[test]
+            fn test_boot_qemu_clear() {
+                test_boot(CLEAR_IMAGE_NAME, &ClearCloudInit {}, spawn_qemu)
+            }
 
-        #[test]
-        #[cfg(not(feature = "coreboot"))]
-        fn test_boot_ch_jammy() {
-            test_boot(JAMMY_IMAGE_NAME, &UbuntuCloudInit {}, spawn_ch)
-        }
+            #[test]
+            #[cfg(not(feature = "coreboot"))]
+            fn test_boot_ch_focal() {
+                test_boot(FOCAL_IMAGE_NAME, &UbuntuCloudInit {}, spawn_ch)
+            }
 
-        #[test]
-        #[cfg(not(feature = "coreboot"))]
-        fn test_boot_ch_clear() {
-            test_boot(CLEAR_IMAGE_NAME, &ClearCloudInit {}, spawn_ch)
+            #[test]
+            #[cfg(not(feature = "coreboot"))]
+            fn test_boot_ch_jammy() {
+                test_boot(JAMMY_IMAGE_NAME, &UbuntuCloudInit {}, spawn_ch)
+            }
+
+            #[test]
+            #[cfg(not(feature = "coreboot"))]
+            fn test_boot_ch_clear() {
+                test_boot(CLEAR_IMAGE_NAME, &ClearCloudInit {}, spawn_ch)
+            }
         }
     }
 
@@ -709,78 +713,83 @@ mod tests {
             handle_child_output(&tmp_dir, r, &output);
         }
 
-        #[test]
-        #[ignore] // Windows guest test on QEMU is not supported yet.
-        #[cfg(not(feature = "coreboot"))]
-        fn test_boot_qemu_windows() {
-            let fw = Firmware {
-                fw_type: "-kernel",
-                path: "target/x86_64-unknown-none/release/hypervisor-fw",
-            };
-            test_boot_qemu_windows_common(&fw);
-        }
+        mod x86_64 {
+            use super::*;
 
-        #[test]
-        #[ignore] // Windows guest test on QEMU is not supported yet.
-        #[cfg(feature = "coreboot")]
-        fn test_boot_qemu_windows() {
-            let fw = Firmware {
-                fw_type: "-bios",
-                path: "resources/coreboot/coreboot/build/coreboot.rom",
-            };
-            test_boot_qemu_windows_common(&fw);
-        }
+            #[test]
+            #[ignore] // Windows guest test on QEMU is not supported yet.
+            #[cfg(not(feature = "coreboot"))]
+            fn test_boot_qemu_windows() {
+                let fw = Firmware {
+                    fw_type: "-kernel",
+                    path: "target/x86_64-unknown-none/release/hypervisor-fw",
+                };
+                test_boot_qemu_windows_common(&fw);
+            }
 
-        #[test]
-        #[cfg(not(feature = "coreboot"))]
-        fn test_boot_ch_windows() {
-            let mut disk = WindowsDiskConfig::new(WINDOWS_IMAGE_NAME.to_string());
-            let tmp_dir = TempDir::new().expect("Expect creating temporary directory to succeed");
-            prepare_windows_os_disk(&mut disk, &tmp_dir);
+            #[test]
+            #[ignore] // Windows guest test on QEMU is not supported yet.
+            #[cfg(feature = "coreboot")]
+            fn test_boot_qemu_windows() {
+                let fw = Firmware {
+                    fw_type: "-bios",
+                    path: "resources/coreboot/coreboot/build/coreboot.rom",
+                };
+                test_boot_qemu_windows_common(&fw);
+            }
 
-            let clh_path = dirs::home_dir()
-                .unwrap()
-                .join("workloads")
-                .join("cloud-hypervisor");
-            let mut c = Command::new(clh_path.to_str().unwrap());
-            c.args([
-                "--cpus",
-                "boot=2,kvm_hyperv=on",
-                "--memory",
-                "size=4G",
-                "--console",
-                "off",
-                "--serial",
-                "tty",
-                "--kernel",
-                "target/x86_64-unknown-none/release/hypervisor-fw",
-                "--disk",
-                &format!("path={}", disk.osdisk_path),
-                "--net",
-                "tap=",
-            ]);
+            #[test]
+            #[cfg(not(feature = "coreboot"))]
+            fn test_boot_ch_windows() {
+                let mut disk = WindowsDiskConfig::new(WINDOWS_IMAGE_NAME.to_string());
+                let tmp_dir =
+                    TempDir::new().expect("Expect creating temporary directory to succeed");
+                prepare_windows_os_disk(&mut disk, &tmp_dir);
 
-            let stdout = fs::File::create(tmp_dir.path().join("stdout")).unwrap();
-            let stderr = fs::File::create(tmp_dir.path().join("stderr")).unwrap();
+                let clh_path = dirs::home_dir()
+                    .unwrap()
+                    .join("workloads")
+                    .join("cloud-hypervisor");
+                let mut c = Command::new(clh_path.to_str().unwrap());
+                c.args([
+                    "--cpus",
+                    "boot=2,kvm_hyperv=on",
+                    "--memory",
+                    "size=4G",
+                    "--console",
+                    "off",
+                    "--serial",
+                    "tty",
+                    "--kernel",
+                    "target/x86_64-unknown-none/release/hypervisor-fw",
+                    "--disk",
+                    &format!("path={}", disk.osdisk_path),
+                    "--net",
+                    "tap=",
+                ]);
 
-            eprintln!("Spawning: {:?}", c);
-            let mut child = c
-                .stdout(Stdio::from(stdout))
-                .stderr(Stdio::from(stderr))
-                .spawn()
-                .expect("Expect launching Cloud Hypervisor to succeed");
+                let stdout = fs::File::create(tmp_dir.path().join("stdout")).unwrap();
+                let stderr = fs::File::create(tmp_dir.path().join("stderr")).unwrap();
 
-            thread::sleep(std::time::Duration::from_secs(60));
-            let r = std::panic::catch_unwind(|| {
-                let auth = windows_auth();
-                ssh_command_with_auth("192.168.249.2", "shutdown /s", &auth)
-                    .expect("Expect SSH command to work");
-            });
+                eprintln!("Spawning: {:?}", c);
+                let mut child = c
+                    .stdout(Stdio::from(stdout))
+                    .stderr(Stdio::from(stderr))
+                    .spawn()
+                    .expect("Expect launching Cloud Hypervisor to succeed");
 
-            child.kill().unwrap();
-            let output = child.wait_with_output().unwrap();
+                thread::sleep(std::time::Duration::from_secs(60));
+                let r = std::panic::catch_unwind(|| {
+                    let auth = windows_auth();
+                    ssh_command_with_auth("192.168.249.2", "shutdown /s", &auth)
+                        .expect("Expect SSH command to work");
+                });
 
-            handle_child_output(&tmp_dir, r, &output);
+                child.kill().unwrap();
+                let output = child.wait_with_output().unwrap();
+
+                handle_child_output(&tmp_dir, r, &output);
+            }
         }
     }
 }

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -465,9 +465,13 @@ mod tests {
         path: &'a str,
     }
 
+    #[cfg(target_arch = "aarch64")]
+    const TARGET_TRIPLE: &str = "aarch64-unknown-none";
     #[cfg(target_arch = "x86_64")]
     const TARGET_TRIPLE: &str = "x86_64-unknown-none";
 
+    #[cfg(target_arch = "aarch64")]
+    const QEMU_NAME: &str = "qemu-system-aarch64";
     #[cfg(target_arch = "x86_64")]
     const QEMU_NAME: &str = "qemu-system-x86_64";
 
@@ -603,6 +607,25 @@ mod tests {
             cleanup_tap(&net);
 
             handle_child_output(&tmp_dir, r, &output);
+        }
+
+        mod aarch64 {
+            use super::*;
+
+            const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-arm64-raw.img";
+            const JAMMY_IMAGE_NAME: &str = "jammy-server-cloudimg-arm64-raw.img";
+
+            #[test]
+            #[cfg(not(feature = "coreboot"))]
+            fn test_boot_ch_focal() {
+                test_boot(FOCAL_IMAGE_NAME, &UbuntuCloudInit {}, spawn_ch)
+            }
+
+            #[test]
+            #[cfg(not(feature = "coreboot"))]
+            fn test_boot_ch_jammy() {
+                test_boot(JAMMY_IMAGE_NAME, &UbuntuCloudInit {}, spawn_ch)
+            }
         }
 
         mod x86_64 {


### PR DESCRIPTION
Since PR #262 was merged, we can boot Ubuntu images using aarch64 Cloud Hypervisor. This PR proposes adding integration tests for aarch64 CH.