### PR TITLE
build: Update toolchain to nightly-2023-08-11

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-05-26"
+channel = "nightly-2023-08-11"
 components = ["rust-src", "clippy", "rustfmt"]
 targets = [
     "aarch64-unknown-linux-gnu",

--- a/scripts/fetch_images.sh
+++ b/scripts/fetch_images.sh
@@ -4,7 +4,7 @@ set -x
 fetch_ch() {
     CH_PATH="$1"
     CH_ARCH="$2"
-    CH_VERSION="v32.0"
+    CH_VERSION="v34.0"
     CH_URL_BASE="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/$CH_VERSION"
 
     [ "$CH_ARCH" = "aarch64" ] && CH_NAME="cloud-hypervisor-static-aarch64"

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -191,8 +191,8 @@ pub struct Header {
 impl Header {
     // Read a kernel header from the first two sectors of a file
     pub fn from_file(f: &mut dyn Read) -> Result<Self, Error> {
-        let mut data: [u8; 1024] = [0; 1024];
-        let mut region = MemoryRegion::from_bytes(&mut data);
+        let data: [u8; 1024] = [0; 1024];
+        let mut region = MemoryRegion::from_bytes(&data);
 
         f.seek(0)?;
         f.load_file(&mut region)?;

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -586,8 +586,7 @@ pub extern "efiapi" fn locate_handle(
 
         let wrappers_as_handles: &[Handle] = unsafe {
             core::slice::from_raw_parts_mut(
-                BLOCK_WRAPPERS.wrappers.as_mut_ptr() as *mut *mut block::BlockWrapper
-                    as *mut Handle,
+                BLOCK_WRAPPERS.wrappers.as_mut_ptr() as *mut Handle,
                 count,
             )
         };

--- a/src/efi/var.rs
+++ b/src/efi/var.rs
@@ -48,7 +48,7 @@ impl VariableAllocator {
             return None;
         }
 
-        let s = unsafe { core::slice::from_raw_parts(name as *const u16, len + 1) };
+        let s = unsafe { core::slice::from_raw_parts(name, len + 1) };
         let mut name: Vec<u16> = Vec::new();
         name.extend_from_slice(s);
         let guid = unsafe { &*guid };
@@ -118,7 +118,7 @@ impl VariableAllocator {
                 return efi::Status::INVALID_PARAMETER;
             }
             let mut a = Descriptor::new();
-            let name = unsafe { core::slice::from_raw_parts(name as *const u16, len + 1) };
+            let name = unsafe { core::slice::from_raw_parts(name, len + 1) };
             a.name.extend_from_slice(name);
             a.guid = unsafe { *guid };
             a.attr = attr & !efi::VARIABLE_APPEND_WRITE;
@@ -225,13 +225,7 @@ mod tests {
 
         let size = 0;
         let attr = ATTR | efi::VARIABLE_APPEND_WRITE;
-        let status = allocator.set(
-            NAME.as_ptr(),
-            &GUID,
-            attr,
-            size,
-            core::ptr::null() as *const core::ffi::c_void,
-        );
+        let status = allocator.set(NAME.as_ptr(), &GUID, attr, size, core::ptr::null());
 
         assert_eq!(status, efi::Status::SUCCESS);
         assert_eq!(allocator.allocations[0].name, NAME);
@@ -263,13 +257,7 @@ mod tests {
 
         let size = 0;
         let attr = ATTR;
-        let status = allocator.set(
-            NAME.as_ptr(),
-            &GUID,
-            attr,
-            size,
-            core::ptr::null() as *const core::ffi::c_void,
-        );
+        let status = allocator.set(NAME.as_ptr(), &GUID, attr, size, core::ptr::null());
 
         assert_eq!(status, efi::Status::SUCCESS);
         assert!(allocator.allocations.is_empty());
@@ -316,7 +304,7 @@ mod tests {
         let status = allocator.get(
             NAME.as_ptr(),
             &GUID,
-            core::ptr::null_mut() as *mut u32,
+            core::ptr::null_mut(),
             &mut size,
             data.as_mut_ptr() as *mut core::ffi::c_void,
         );

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -122,7 +122,7 @@ mod tests {
                 .join("cloud-init")
                 .join("ubuntu");
 
-            vec!["meta-data", "user-data"].iter().for_each(|x| {
+            ["meta-data", "user-data"].iter().for_each(|x| {
                 fs::copy(source_file_dir.join(x), cloud_init_directory.join(x))
                     .expect("Expect copying cloud-init meta-data to succeed");
             });
@@ -151,7 +151,7 @@ mod tests {
                 .output()
                 .expect("Expect creating disk image to succeed");
 
-            vec!["user-data", "meta-data", "network-config"]
+            ["user-data", "meta-data", "network-config"]
                 .iter()
                 .for_each(|x| {
                     std::process::Command::new("mcopy")

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 #![feature(slice_take)]
 #![feature(stdsimd)]
 #![feature(stmt_expr_attributes)]
+#![feature(strict_provenance)]
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -16,7 +16,7 @@ impl MemoryRegion {
     }
 
     /// Take a slice and turn it into a region of memory
-    pub fn from_bytes(data: &mut [u8]) -> MemoryRegion {
+    pub fn from_bytes(data: &[u8]) -> MemoryRegion {
         MemoryRegion {
             base: data.as_ptr() as u64,
             length: data.len() as u64,

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -78,7 +78,7 @@ impl<'a> Loader<'a> {
             return Err(Error::FileError);
         }
 
-        let dos_region = MemoryRegion::from_bytes(&mut data);
+        let dos_region = MemoryRegion::from_bytes(&data);
 
         // 'MZ' magic
         if dos_region.read_u16(0) != 0x5a4d {
@@ -92,7 +92,7 @@ impl<'a> Loader<'a> {
             return Err(Error::InvalidExecutable);
         }
 
-        let pe_region = MemoryRegion::from_bytes(&mut data[pe_header_offset as usize..]);
+        let pe_region = MemoryRegion::from_bytes(&data[pe_header_offset as usize..]);
 
         // The Microsoft specification uses offsets relative to the COFF area
         // which is 4 after the signature (so all offsets are +4 relative to the spec)
@@ -109,8 +109,7 @@ impl<'a> Loader<'a> {
         self.num_sections = pe_region.read_u16(6);
 
         let optional_header_size = pe_region.read_u16(20);
-        let optional_region =
-            MemoryRegion::from_bytes(&mut data[(24 + pe_header_offset) as usize..]);
+        let optional_region = MemoryRegion::from_bytes(&data[(24 + pe_header_offset) as usize..]);
 
         if optional_region.read_u16(0) != Self::OPTIONAL_HEADER_MAGIC {
             return Err(Error::InvalidExecutable);


### PR DESCRIPTION
This PR proposes updating Rust toolchain to nightly-2023-08-11. With this update, we need to change some of the code as suggested by clippy. It also includes fix potential unaligned access in PE loader.