### PR TITLE
build: Bump chrono from 0.4.26 to 0.4.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "atomic_refcell"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,11 +55,10 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
 dependencies = [
- "android-tzdata",
  "num-traits",
 ]
 

--- a/src/rtc_goldfish.rs
+++ b/src/rtc_goldfish.rs
@@ -3,7 +3,7 @@
 
 use crate::mem::MemoryRegion;
 use atomic_refcell::AtomicRefCell;
-use chrono::{DateTime, Datelike, NaiveDateTime, Timelike, Utc};
+use chrono::{Datelike, NaiveDateTime, Timelike};
 
 // TODO: Fill from FDT
 const RTC_GOLDFISH_ADDRESS: u64 = 0x101000;
@@ -36,7 +36,7 @@ pub fn read_date() -> Result<(u8, u8, u8), ()> {
     let ts = RTC_GOLDFISH.borrow_mut().read_ts();
 
     let naive = NaiveDateTime::from_timestamp_opt(ts as i64, 0).ok_or(())?;
-    let datetime: DateTime<Utc> = DateTime::from_utc(naive, Utc);
+    let datetime = naive.and_utc();
     Ok((
         (datetime.year() - 2000) as u8,
         datetime.month() as u8,
@@ -47,7 +47,7 @@ pub fn read_date() -> Result<(u8, u8, u8), ()> {
 pub fn read_time() -> Result<(u8, u8, u8), ()> {
     let ts = RTC_GOLDFISH.borrow_mut().read_ts();
     let naive = NaiveDateTime::from_timestamp_opt(ts as i64, 0).ok_or(())?;
-    let datetime: DateTime<Utc> = DateTime::from_utc(naive, Utc);
+    let datetime = naive.and_utc();
     Ok((
         datetime.hour() as u8,
         datetime.minute() as u8,

--- a/src/rtc_pl031.rs
+++ b/src/rtc_pl031.rs
@@ -2,7 +2,7 @@
 // Copyright (C) 2022 Akira Moroo
 
 use atomic_refcell::AtomicRefCell;
-use chrono::{DateTime, Datelike, NaiveDateTime, Timelike, Utc};
+use chrono::{Datelike, NaiveDateTime, Timelike};
 
 use crate::{arch::aarch64::layout::map, mem};
 
@@ -28,7 +28,7 @@ impl Pl031 {
     pub fn read_date(&self) -> Result<(u8, u8, u8), ()> {
         let timestamp = self.read_timestamp();
         let naive = NaiveDateTime::from_timestamp_opt(timestamp as i64, 0).ok_or(())?;
-        let datetime: DateTime<Utc> = DateTime::from_utc(naive, Utc);
+        let datetime = naive.and_utc();
         Ok((
             (datetime.year() - 2000) as u8,
             datetime.month() as u8,
@@ -39,7 +39,7 @@ impl Pl031 {
     pub fn read_time(&self) -> Result<(u8, u8, u8), ()> {
         let timestamp = self.read_timestamp();
         let naive = NaiveDateTime::from_timestamp_opt(timestamp as i64, 0).ok_or(())?;
-        let datetime: DateTime<Utc> = DateTime::from_utc(naive, Utc);
+        let datetime = naive.and_utc();
         Ok((
             datetime.hour() as u8,
             datetime.minute() as u8,


### PR DESCRIPTION
This PR proposes updating chrono to 0.4.28 and remove use of deprecated functions.