### PR TITLE
build: Bump tock-registers from 0.8.1 to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "9.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac42a04a61c19fc8196dd728022a784baecc5d63d7e256c01ad1b3fbfab26287"
 dependencies = [
- "tock-registers",
+ "tock-registers 0.8.1",
 ]
 
 [[package]]
@@ -142,7 +142,7 @@ dependencies = [
  "rand",
  "ssh2",
  "tempfile",
- "tock-registers",
+ "tock-registers 0.9.0",
  "uart_16550",
  "x86_64",
 ]
@@ -430,6 +430,12 @@ name = "tock-registers"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "696941a0aee7e276a165a978b37918fd5d22c55c3d6bda197813070ca9c0f21c"
+
+[[package]]
+name = "tock-registers"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
 
 [[package]]
 name = "uart_16550"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ r-efi = { version = "4.3.0", features = ["efiapi"] }
 linked_list_allocator = "0.10.4"
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
-tock-registers = "0.8.1"
+tock-registers = "0.9.0"
 aarch64-cpu = "9.4.0"
 fdt = "0.1.5"
 chrono = { version = "0.4", default-features = false }

--- a/src/arch/aarch64/paging.rs
+++ b/src/arch/aarch64/paging.rs
@@ -4,8 +4,10 @@
 
 use core::ops::RangeInclusive;
 
-use aarch64_cpu::{asm::barrier, registers::*};
-use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
+use aarch64_cpu::{
+    asm::barrier,
+    registers::{Readable, Writeable, *},
+};
 
 use self::interface::Mmu;
 
@@ -287,7 +289,10 @@ impl interface::Mmu for MemoryManagementUnit {
         barrier::isb(barrier::SY);
 
         // Enable the MMU and turn on data and instruction caching.
-        SCTLR_EL1.modify(SCTLR_EL1::M::Enable + SCTLR_EL1::C::Cacheable + SCTLR_EL1::I::Cacheable);
+        SCTLR_EL1.modify_no_read(
+            SCTLR_EL1.extract(),
+            SCTLR_EL1::M::Enable + SCTLR_EL1::C::Cacheable + SCTLR_EL1::I::Cacheable,
+        );
 
         // Force MMU init to complete before next instruction.
         barrier::isb(barrier::SY);

--- a/src/arch/aarch64/simd.rs
+++ b/src/arch/aarch64/simd.rs
@@ -2,8 +2,7 @@
 // Copyright (C) 2023 Akira Moroo
 
 use aarch64_cpu::registers::*;
-use tock_registers::interfaces::ReadWriteable;
 
 pub fn setup_simd() {
-    CPACR_EL1.modify(CPACR_EL1::FPEN::TrapNothing);
+    CPACR_EL1.modify_no_read(CPACR_EL1.extract(), CPACR_EL1::FPEN::TrapNothing);
 }


### PR DESCRIPTION
This PR fixes build error seen in PR #282.