### PR TITLE
layout: Add MMIO memory attribute

### DIFF
--- a/src/arch/aarch64/layout.rs
+++ b/src/arch/aarch64/layout.rs
@@ -79,6 +79,10 @@ pub fn virt_mem_layout() -> &'static KernelVirtualLayout<NUM_MEM_RANGES> {
     &LAYOUT
 }
 
+pub fn mmio_range() -> Range<usize> {
+    map::mmio::START..map::mmio::END
+}
+
 pub fn reserved_range() -> Range<usize> {
     map::dram::START..map::dram::KERNEL_START
 }
@@ -95,9 +99,14 @@ pub fn stack_range() -> Range<usize> {
     unsafe { (stack_start.get() as _)..(stack_end.get() as _) }
 }
 
-const NUM_MEM_DESCS: usize = 4;
+const NUM_MEM_DESCS: usize = 5;
 
 pub static MEM_LAYOUT: MemoryLayout<NUM_MEM_DESCS> = [
+    MemoryDescriptor {
+        name: "MMIO",
+        range: mmio_range,
+        attribute: MemoryAttribute::Mmio,
+    },
     MemoryDescriptor {
         name: "Reserved",
         range: reserved_range,

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -976,6 +976,7 @@ fn populate_allocator(info: &dyn bootinfo::Info, image_address: u64, image_size:
             layout::MemoryAttribute::Code => efi::RUNTIME_SERVICES_CODE,
             layout::MemoryAttribute::Data => efi::RUNTIME_SERVICES_DATA,
             layout::MemoryAttribute::Unusable => efi::UNUSABLE_MEMORY,
+            layout::MemoryAttribute::Mmio => efi::MEMORY_MAPPED_IO,
         };
         ALLOCATOR.borrow_mut().allocate_pages(
             efi::ALLOCATE_ADDRESS,

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -995,15 +995,6 @@ fn populate_allocator(info: &dyn bootinfo::Info, image_address: u64, image_size:
         );
     }
 
-    // Add IO map for RTC PL031 on aarch64
-    #[cfg(target_arch = "aarch64")]
-    ALLOCATOR.borrow_mut().add_initial_allocation(
-        efi::MEMORY_MAPPED_IO,
-        1,
-        crate::arch::aarch64::layout::map::mmio::PL031_START as u64,
-        r_efi::efi::MEMORY_RUNTIME,
-    );
-
     // Add the loaded binary
     ALLOCATOR.borrow_mut().allocate_pages(
         efi::ALLOCATE_ADDRESS,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -3,12 +3,13 @@
 
 use core::ops::Range;
 
+#[allow(dead_code)]
 #[derive(Clone, Copy)]
 pub enum MemoryAttribute {
     Code,
     Data,
-    #[allow(dead_code)]
     Unusable,
+    Mmio,
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
As reported in issue #289, there was an allocation issue with the MMIO region for AArch64 in the EFI layer. This was initially addressed by PR #290, thanks to @jongwu. However, the solution appeared to be somewhat ad-hoc, raising same concerns with the RL011 UART MMIO region.

This PR adds `MemoryAttribute::Mmio` and an MMIO memory descriptor for AArch64 memory layout.