### PR TITLE
riscv64: Avoid F and V instruction generation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,8 @@
 fn main() {
     println!("cargo:rerun-if-changed=aarch64-unknown-none.json");
     println!("cargo:rerun-if-changed=aarch64-unknown-none.ld");
+    println!("cargo:rerun-if-changed=riscv64gcv-unknown-none-elf.json");
+    println!("cargo:rerun-if-changed=riscv64gcv-unknown-none-elf.ld");
     println!("cargo:rerun-if-changed=x86_64-unknown-none.json");
     println!("cargo:rerun-if-changed=x86_64-unknown-none.ld");
 }

--- a/riscv64gcv-unknown-none-elf.json
+++ b/riscv64gcv-unknown-none-elf.json
@@ -5,7 +5,7 @@
   "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n64-S128",
   "eh-frame-header": false,
   "emit-debug-gdb-scripts": false,
-  "features": "+m,+a,+f,+d,+c,+v",
+  "features": "+m,+a,-f,+d,+c,-v",
   "is-builtin": false,
   "linker": "rust-lld",
   "linker-flavor": "ld.lld",


### PR DESCRIPTION
As reported in issue https://github.com/cloud-hypervisor/rust-hypervisor-firmware/issues/299, the latest RHF goes boot loop since `nightly-2023-06-07` Rust toolchain. This is because the recent Rust generates code that includes F and V extensions, which we need to enable these features on startup. This commit disables generation of these extensions as a workaround.

Fixes #299.