### PR TITLE
scripts: Use current image for jammy

### DIFF
--- a/scripts/fetch_images.sh
+++ b/scripts/fetch_images.sh
@@ -48,7 +48,7 @@ fetch_raw_ubuntu_image() {
 
 aarch64_fetch_disk_images() {
     fetch_raw_ubuntu_image "focal" "arm64" "current"
-    fetch_raw_ubuntu_image "jammy" "arm64" "20231026"
+    fetch_raw_ubuntu_image "jammy" "arm64" "current"
 }
 
 x86_64_fetch_disk_images() {
@@ -58,7 +58,7 @@ x86_64_fetch_disk_images() {
     fetch_image "$CLEAR_OS_IMAGE_NAME" "$CLEAR_OS_IMAGE_URL"
 
     fetch_raw_ubuntu_image "focal" "amd64" "current"
-    fetch_raw_ubuntu_image "jammy" "amd64" "20231026"
+    fetch_raw_ubuntu_image "jammy" "amd64" "current"
 }
 
 fetch_disk_images() {


### PR DESCRIPTION
Tracking older images is fine for a short period for when we need to
avoid issues but only the most recent images are kept so ultimately we
should track current.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
