### PR TITLE
EFI device path improvements

### DIFF
--- a/src/efi/file.rs
+++ b/src/efi/file.rs
@@ -16,7 +16,7 @@ use crate::block::SectorBuf;
 #[repr(C)]
 pub struct FileDevicePathProtocol {
     pub device_path: DevicePathProtocol,
-    pub filename: [u16; 64],
+    pub filename: [u16; 128],
 }
 
 pub extern "efiapi" fn filesystem_open_volume(

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -1206,8 +1206,12 @@ pub fn efi_exec(
 
     let wrapped_fs = file::FileSystemWrapper::new(fs, efi_part_id);
 
+    let mut path = [0u8; 256];
+    path[0..crate::efi::EFI_BOOT_PATH.as_bytes().len()]
+        .copy_from_slice(crate::efi::EFI_BOOT_PATH.as_bytes());
+    let device_path = DevicePath::File(path);
     let image = new_image_handle(
-        file_device_path(crate::efi::EFI_BOOT_PATH),
+        device_path.generate(),
         0 as Handle,
         &wrapped_fs as *const _ as Handle,
         loaded_address,

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -1067,9 +1067,9 @@ fn file_device_path(path: &str) -> *mut r_efi::protocols::device_path::Protocol 
             device_path: DevicePathProtocol {
                 r#type: r_efi::protocols::device_path::TYPE_MEDIA,
                 sub_type: 4, // Media Path type file
-                length: [132, 0],
+                length: [(260u16 & 0xff) as u8, (260u16 >> 8) as u8],
             },
-            filename: [0; 64],
+            filename: [0; 128],
         },
         file::FileDevicePathProtocol {
             device_path: DevicePathProtocol {
@@ -1077,7 +1077,7 @@ fn file_device_path(path: &str) -> *mut r_efi::protocols::device_path::Protocol 
                 sub_type: 0xff, // End of full path
                 length: [4, 0],
             },
-            filename: [0; 64],
+            filename: [0; 128],
         },
     ];
 


### PR DESCRIPTION
- efi: Refactor device path protocol parsing
- efi: Refactor construction of file based device path
- efi: Refactor EFI device path generatation for loaded image
- efi: Use DevicePath::generate() for executing the main EFI binary
