### PR TITLE
Boot from memory device path

### DIFF
--- a/src/efi/file.rs
+++ b/src/efi/file.rs
@@ -6,18 +6,11 @@ use core::ffi::c_void;
 use r_efi::{
     efi::{self, Char16, Guid, Status},
     protocols::{
-        device_path::Protocol as DevicePathProtocol, file::Protocol as FileProtocol,
-        simple_file_system::Protocol as SimpleFileSystemProtocol,
+        file::Protocol as FileProtocol, simple_file_system::Protocol as SimpleFileSystemProtocol,
     },
 };
 
 use crate::block::SectorBuf;
-
-#[repr(C)]
-pub struct FileDevicePathProtocol {
-    pub device_path: DevicePathProtocol,
-    pub filename: [u16; 64],
-}
 
 pub extern "efiapi" fn filesystem_open_volume(
     fs_proto: *mut SimpleFileSystemProtocol,

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -1051,7 +1051,13 @@ struct LoadedImageWrapper {
     entry_point: u64,
 }
 
-type DevicePaths = [file::FileDevicePathProtocol; 2];
+#[repr(C)]
+struct FileDevicePathProtocol {
+    pub device_path: DevicePathProtocol,
+    pub filename: [u16; 64],
+}
+
+type DevicePaths = [FileDevicePathProtocol; 2];
 
 fn file_device_path(path: &str) -> *mut r_efi::protocols::device_path::Protocol {
     let mut file_paths = null_mut();
@@ -1063,7 +1069,7 @@ fn file_device_path(path: &str) -> *mut r_efi::protocols::device_path::Protocol 
     assert!(status == Status::SUCCESS);
     let file_paths = unsafe { &mut *(file_paths as *mut DevicePaths) };
     *file_paths = [
-        file::FileDevicePathProtocol {
+        FileDevicePathProtocol {
             device_path: DevicePathProtocol {
                 r#type: r_efi::protocols::device_path::TYPE_MEDIA,
                 sub_type: 4, // Media Path type file
@@ -1071,7 +1077,7 @@ fn file_device_path(path: &str) -> *mut r_efi::protocols::device_path::Protocol 
             },
             filename: [0; 64],
         },
-        file::FileDevicePathProtocol {
+        FileDevicePathProtocol {
             device_path: DevicePathProtocol {
                 r#type: r_efi::protocols::device_path::TYPE_END,
                 sub_type: 0xff, // End of full path

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -1057,17 +1057,17 @@ struct FileDevicePathProtocol {
     pub filename: [u16; 256],
 }
 
-type DevicePaths = [FileDevicePathProtocol; 2];
+type FileDevicePaths = [FileDevicePathProtocol; 2];
 
 fn file_device_path(path: &str) -> *mut r_efi::protocols::device_path::Protocol {
     let mut file_paths = null_mut();
     let status = allocate_pool(
         efi::LOADER_DATA,
-        size_of::<DevicePaths>(),
+        size_of::<FileDevicePaths>(),
         &mut file_paths as *mut *mut c_void,
     );
     assert!(status == Status::SUCCESS);
-    let file_paths = unsafe { &mut *(file_paths as *mut DevicePaths) };
+    let file_paths = unsafe { &mut *(file_paths as *mut FileDevicePaths) };
     *file_paths = [
         FileDevicePathProtocol {
             device_path: DevicePathProtocol {

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -940,6 +940,7 @@ extern "efiapi" fn image_unload(_: Handle) -> Status {
 #[allow(clippy::large_enum_variant)]
 enum DevicePath {
     File([u8; 256]),
+    Memory(MemoryType, u64, u64),
     Unsupported,
 }
 
@@ -954,6 +955,24 @@ impl DevicePath {
                 crate::common::ucs2_to_ascii(ptr, &mut path);
                 return DevicePath::File(path);
             }
+            if dpp.r#type == r_efi::protocols::device_path::TYPE_HARDWARE
+                && dpp.sub_type == r_efi::protocols::device_path::Hardware::SUBTYPE_MMAP
+            {
+                let memory_type_ptr = (dpp as *const _ as usize
+                    + offset_of!(MemoryDevicePathProtocol, memory_type))
+                    as *const MemoryType;
+                let start_ptr = (dpp as *const _ as usize
+                    + offset_of!(MemoryDevicePathProtocol, start))
+                    as *const u64;
+                let end_ptr = (dpp as *const _ as usize + offset_of!(MemoryDevicePathProtocol, end))
+                    as *const u64;
+                return DevicePath::Memory(
+                    unsafe { *memory_type_ptr },
+                    unsafe { *start_ptr },
+                    unsafe { *end_ptr },
+                );
+            }
+
             if dpp.r#type == r_efi::protocols::device_path::TYPE_END && dpp.sub_type == 0xff {
                 log!("Unexpected end of device path");
                 return DevicePath::Unsupported;
@@ -966,6 +985,7 @@ impl DevicePath {
     fn generate(&self) -> *mut r_efi::protocols::device_path::Protocol {
         match self {
             Self::File(path) => file_device_path(crate::common::ascii_strip(path)),
+            Self::Memory(memory_type, start, end) => memory_device_path(*memory_type, *start, *end),
             Self::Unsupported => panic!("Cannot generate from unsupported Device Path type"),
         }
     }
@@ -1090,6 +1110,55 @@ fn file_device_path(path: &str) -> *mut r_efi::protocols::device_path::Protocol 
     crate::common::ascii_to_ucs2(path, &mut file_paths[0].filename);
 
     &mut file_paths[0].device_path // Pointer to first path entry
+}
+
+#[repr(C)]
+struct MemoryDevicePathProtocol {
+    pub device_path: DevicePathProtocol,
+    pub memory_type: u32,
+    pub start: u64,
+    pub end: u64,
+}
+
+type MemoryDevicePaths = [MemoryDevicePathProtocol; 2];
+
+fn memory_device_path(
+    memory_type: MemoryType,
+    start: u64,
+    end: u64,
+) -> *mut r_efi::protocols::device_path::Protocol {
+    let mut memory_paths = null_mut();
+    let status = allocate_pool(
+        efi::LOADER_DATA,
+        size_of::<MemoryDevicePaths>(),
+        &mut memory_paths as *mut *mut c_void,
+    );
+    assert!(status == Status::SUCCESS);
+    let memory_paths = unsafe { &mut *(memory_paths as *mut MemoryDevicePaths) };
+    *memory_paths = [
+        MemoryDevicePathProtocol {
+            device_path: DevicePathProtocol {
+                r#type: r_efi::protocols::device_path::TYPE_HARDWARE,
+                sub_type: r_efi::protocols::device_path::Hardware::SUBTYPE_MMAP,
+                length: (size_of::<MemoryDevicePathProtocol>() as u16).to_le_bytes(),
+            },
+            memory_type,
+            start,
+            end,
+        },
+        MemoryDevicePathProtocol {
+            device_path: DevicePathProtocol {
+                r#type: r_efi::protocols::device_path::TYPE_END,
+                sub_type: r_efi::protocols::device_path::End::SUBTYPE_ENTIRE,
+                length: (size_of::<DevicePathProtocol>() as u16).to_le_bytes(),
+            },
+            memory_type: 0,
+            start: 0,
+            end: 0,
+        },
+    ];
+
+    &mut memory_paths[0].device_path // Pointer to first path entry
 }
 
 fn new_image_handle(

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -1206,8 +1206,12 @@ pub fn efi_exec(
 
     let wrapped_fs = file::FileSystemWrapper::new(fs, efi_part_id);
 
+    let mut path = [0u8; 256];
+    path[0..crate::efi::EFI_BOOT_PATH.as_bytes().len()]
+        .copy_from_slice(crate::efi::EFI_BOOT_PATH.as_bytes());
+    let device_path = DevicePath::File(path);
     let image = new_image_handle(
-        file_device_path(crate::efi::EFI_BOOT_PATH),
+        device_path.generate(),
         0 as Handle,
         &wrapped_fs as *const _ as Handle,
         loaded_address,

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -1054,7 +1054,7 @@ struct LoadedImageWrapper {
 #[repr(C)]
 struct FileDevicePathProtocol {
     pub device_path: DevicePathProtocol,
-    pub filename: [u16; 64],
+    pub filename: [u16; 256],
 }
 
 type DevicePaths = [FileDevicePathProtocol; 2];
@@ -1073,17 +1073,17 @@ fn file_device_path(path: &str) -> *mut r_efi::protocols::device_path::Protocol 
             device_path: DevicePathProtocol {
                 r#type: r_efi::protocols::device_path::TYPE_MEDIA,
                 sub_type: 4, // Media Path type file
-                length: [132, 0],
+                length: (size_of::<FileDevicePathProtocol>() as u16).to_le_bytes(),
             },
-            filename: [0; 64],
+            filename: [0; 256],
         },
         FileDevicePathProtocol {
             device_path: DevicePathProtocol {
                 r#type: r_efi::protocols::device_path::TYPE_END,
-                sub_type: 0xff, // End of full path
-                length: [4, 0],
+                sub_type: r_efi::protocols::device_path::End::SUBTYPE_ENTIRE,
+                length: (size_of::<DevicePathProtocol>() as u16).to_le_bytes(),
             },
-            filename: [0; 64],
+            filename: [0; 256],
         },
     ];
 

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -653,54 +653,57 @@ pub extern "efiapi" fn load_image(
 ) -> Status {
     use crate::fat::Read;
 
-    let mut path = [0_u8; 256];
     let device_path = unsafe { &*device_path };
-    extract_path(device_path, &mut path);
-    let path = crate::common::ascii_strip(&path);
+    match DevicePath::parse(device_path) {
+        DevicePath::File(path) => {
+            let path = crate::common::ascii_strip(&path);
 
-    let li = parent_image_handle as *const LoadedImageWrapper;
-    let dh = unsafe { (*li).proto.device_handle };
-    let wrapped_fs_ref = unsafe { &*(dh as *const file::FileSystemWrapper) };
-    let mut file = match wrapped_fs_ref.fs.open(path) {
-        Ok(file) => file,
-        Err(_) => return Status::DEVICE_ERROR,
-    };
+            let li = parent_image_handle as *const LoadedImageWrapper;
+            let dh = unsafe { (*li).proto.device_handle };
+            let wrapped_fs_ref = unsafe { &*(dh as *const file::FileSystemWrapper) };
+            let mut file = match wrapped_fs_ref.fs.open(path) {
+                Ok(file) => file,
+                Err(_) => return Status::DEVICE_ERROR,
+            };
 
-    let file_size = (file.get_size() as u64 + PAGE_SIZE - 1) / PAGE_SIZE;
-    // Get free pages address
-    let load_addr =
-        match ALLOCATOR
-            .borrow_mut()
-            .find_free_pages(efi::ALLOCATE_ANY_PAGES, file_size, 0)
-        {
-            Some(a) => a,
-            None => return Status::OUT_OF_RESOURCES,
-        };
+            let file_size = (file.get_size() as u64 + PAGE_SIZE - 1) / PAGE_SIZE;
+            // Get free pages address
+            let load_addr =
+                match ALLOCATOR
+                    .borrow_mut()
+                    .find_free_pages(efi::ALLOCATE_ANY_PAGES, file_size, 0)
+                {
+                    Some(a) => a,
+                    None => return Status::OUT_OF_RESOURCES,
+                };
 
-    let mut l = crate::pe::Loader::new(&mut file);
-    let (entry_addr, load_addr, load_size) = match l.load(load_addr) {
-        Ok(load_info) => load_info,
-        Err(_) => return Status::DEVICE_ERROR,
-    };
-    ALLOCATOR.borrow_mut().allocate_pages(
-        efi::ALLOCATE_ADDRESS,
-        efi::LOADER_CODE,
-        file_size,
-        load_addr,
-    );
+            let mut l = crate::pe::Loader::new(&mut file);
+            let (entry_addr, load_addr, load_size) = match l.load(load_addr) {
+                Ok(load_info) => load_info,
+                Err(_) => return Status::DEVICE_ERROR,
+            };
+            ALLOCATOR.borrow_mut().allocate_pages(
+                efi::ALLOCATE_ADDRESS,
+                efi::LOADER_CODE,
+                file_size,
+                load_addr,
+            );
 
-    let image = new_image_handle(
-        path,
-        parent_image_handle,
-        wrapped_fs_ref as *const _ as Handle,
-        load_addr,
-        load_size,
-        entry_addr,
-    );
+            let image = new_image_handle(
+                path,
+                parent_image_handle,
+                wrapped_fs_ref as *const _ as Handle,
+                load_addr,
+                load_size,
+                entry_addr,
+            );
 
-    unsafe { *image_handle = image as *mut _ as *mut c_void };
+            unsafe { *image_handle = image as *mut _ as *mut c_void };
 
-    Status::SUCCESS
+            Status::SUCCESS
+        }
+        _ => Status::UNSUPPORTED,
+    }
 }
 
 pub extern "efiapi" fn start_image(
@@ -934,20 +937,30 @@ extern "efiapi" fn image_unload(_: Handle) -> Status {
     efi::Status::UNSUPPORTED
 }
 
-fn extract_path(device_path: &DevicePathProtocol, path: &mut [u8]) {
-    let mut dp = device_path;
-    loop {
-        if dp.r#type == r_efi::protocols::device_path::TYPE_MEDIA && dp.sub_type == 0x04 {
-            let ptr =
-                (dp as *const _ as u64 + size_of::<DevicePathProtocol>() as u64) as *const u16;
-            crate::common::ucs2_to_ascii(ptr, path);
-            return;
+#[allow(clippy::large_enum_variant)]
+enum DevicePath {
+    File([u8; 256]),
+    Unsupported,
+}
+
+impl DevicePath {
+    fn parse(dpp: &DevicePathProtocol) -> DevicePath {
+        let mut dpp = dpp;
+        loop {
+            if dpp.r#type == r_efi::protocols::device_path::TYPE_MEDIA && dpp.sub_type == 0x04 {
+                let ptr = (dpp as *const _ as usize + offset_of!(FileDevicePathProtocol, filename))
+                    as *const u16;
+                let mut path = [0u8; 256];
+                crate::common::ucs2_to_ascii(ptr, &mut path);
+                return DevicePath::File(path);
+            }
+            if dpp.r#type == r_efi::protocols::device_path::TYPE_END && dpp.sub_type == 0xff {
+                log!("Unexpected end of device path");
+                return DevicePath::Unsupported;
+            }
+            let len = unsafe { core::mem::transmute::<[u8; 2], u16>(dpp.length) };
+            dpp = unsafe { &*((dpp as *const _ as u64 + len as u64) as *const _) };
         }
-        if dp.r#type == r_efi::protocols::device_path::TYPE_END && dp.sub_type == 0xff {
-            panic!("Failed to extract path");
-        }
-        let len = unsafe { core::mem::transmute::<[u8; 2], u16>(dp.length) };
-        dp = unsafe { &*((dp as *const _ as u64 + len as u64) as *const _) };
     }
 }
 


### PR DESCRIPTION
- efi: Refactor device path protocol parsing
- efi: Refactor construction of file based device path
- efi: Refactor EFI device path generatation for loaded image
- efi: Use DevicePath::generate() for executing the main EFI binary
- efi: Consistently support filenames up to 256 characters
- efi: Move FileDevicePathProtocol struct to where it is used
- efi: Clarify naming of type for two FileDevicePathProtocol
- efi: Add support for memory mapped device path
- efi: Add support for booting from a memory mapped device path
- efi: Refactor code for loading image

GRUB on (at least RISC-V) loads the guest kernel directly into memory and then
expects the firmware to parse it from there - it does this by using a device
path of type PCI and subtype memory mapped.

With this change the Linux kernel boots on RISC-V if the kernel command line is
modified to specify a fixed rootfs as there are issues with the initramfs.
