### PR TITLE
virtio-pci: use 2 32-bit writes for 64-bit fields

### DIFF
--- a/src/pci.rs
+++ b/src/pci.rs
@@ -564,17 +564,20 @@ impl VirtioTransport for VirtioPciTransport {
 
     fn set_descriptors_address(&self, addr: u64) {
         // queue_desc: 0x20
-        self.region.io_write_u64(0x20, addr);
+        self.region.io_write_u32(0x20, (addr & 0xffff_ffff) as u32);
+        self.region.io_write_u32(0x20 + 4, (addr >> 32) as u32);
     }
 
     fn set_avail_ring(&self, addr: u64) {
         // queue_avail: 0x28
-        self.region.io_write_u64(0x28, addr);
+        self.region.io_write_u32(0x28, (addr & 0xffff_ffff) as u32);
+        self.region.io_write_u32(0x28 + 4, (addr >> 32) as u32);
     }
 
     fn set_used_ring(&self, addr: u64) {
-        // queue_used: 0x28
-        self.region.io_write_u64(0x30, addr);
+        // queue_used: 0x30
+        self.region.io_write_u32(0x30, (addr & 0xffff_ffff) as u32);
+        self.region.io_write_u32(0x30 + 4, (addr >> 32) as u32);
     }
 
     fn set_queue_enable(&self) {


### PR DESCRIPTION
As per virtio spec 4.1.3.1 [1]:

> For device configuration access, the driver MUST use 8-bit wide
> accesses for 8-bit wide fields, 16-bit wide and aligned accesses for
> 16-bit wide fields and 32-bit wide and aligned accesses for 32-bit
> and 64-bit wide fields.

This patch makes the virtio-pci driver sets 64-bit addresses with 2 32-bit writes to align with the spec.

[1] https://docs.oasis-open.org/virtio/virtio/v1.2/csd01/virtio-v1.2-csd01.html#x1-1220001