### PR TITLE
ci: Migrate some integration tests to GitHub actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,20 @@
+name: Rust Hypervisor Firmware Tests
+on: [pull_request, create]
+
+jobs:
+  build:
+    name: Tests
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run unit tests
+        run: scripts/dev_cli.sh tests --unit
+      - name: Run integration tests
+        run: scripts/dev_cli.sh tests --integration
+      - name: Run integration tests
+        run: scripts/dev_cli.sh tests --integration-coreboot

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,37 +3,6 @@ pipeline {
         stages {
                 stage ('Build') {
                         parallel {
-                                stage ('Linux guest Tests') {
-                                        agent { node { label 'focal-fw' } }
-                                        stages {
-                                                stage ('Checkout') {
-                                                        steps {
-                                                                checkout scm
-                                                        }
-                                                }
-                                                stage('Run unit tests') {
-                                                          steps {
-                                                                  sh "scripts/dev_cli.sh tests --unit"
-                                                          }
-                                                }
-                                                stage('Run integration tests') {
-                                                          options {
-                                                                  timeout(time: 1, unit: 'HOURS')
-                                                          }
-                                                          steps {
-                                                                  sh "scripts/dev_cli.sh tests --integration"
-                                                          }
-                                                }
-                                                stage('Run coreboot integration tests') {
-                                                          options {
-                                                                  timeout(time: 1, unit: 'HOURS')
-                                                          }
-                                                          steps {
-                                                                  sh "scripts/dev_cli.sh tests --integration-coreboot"
-                                                          }
-                                                }
-                                        }
-                                }
                                 stage ('Windows guest Tests') {
                                         agent { node { label 'focal-fw' } }
                                         environment {

--- a/scripts/run_coreboot_integration_tests.sh
+++ b/scripts/run_coreboot_integration_tests.sh
@@ -26,4 +26,4 @@ make -C $COREBOOT_DIR olddefconfig
 make -C $COREBOOT_DIR -j"$(nproc)"
 
 export RUST_BACKTRACE=1
-cargo test --features "coreboot integration_tests" "integration::tests::linux::$arch"
+cargo test --features "coreboot integration_tests" "integration::tests::linux::$arch" -- --test-threads=1

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -21,4 +21,4 @@ rustup component add rust-src
 cargo build --release --target "$target.json" -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
 
 export RUST_BACKTRACE=1
-time cargo test --features "integration_tests" "integration::tests::linux::$arch"
+time cargo test --features "integration_tests" "integration::tests::linux::$arch" -- --test-threads=1


### PR DESCRIPTION
Migrate the basic x86-64 integration tests to run on GitHub actions.

- scripts: Run integration tests in series
- ci: Run unit & integration tests on GitHub runner
- ci: Remove x86-64 Linux tests from Jenkinsfile
