### PR TITLE
ci: Switch arm64 tests to self-hosted GitHub Actions runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
   build:
     if: github.event_name == 'pull_request'
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
             tests: false
     steps:
       - name: Code checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install Rust toolchain

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Code checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Code checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Code checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install Rust toolchain

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ jobs:
   release:
     if: github.event_name == 'create' && github.event.ref_type == 'tag'
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Code checkout
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
             coreboot-tests: false
     steps:
       - name: Code checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Run unit tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,9 +4,15 @@ on: [pull_request, create]
 jobs:
   build:
     name: Tests
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-22.04
+            coreboot-tests: true
+          - runner: focal-arm64
+            coreboot-tests: false
     steps:
       - name: Code checkout
         uses: actions/checkout@v2
@@ -16,5 +22,6 @@ jobs:
         run: scripts/dev_cli.sh tests --unit
       - name: Run integration tests
         run: scripts/dev_cli.sh tests --integration
-      - name: Run integration tests
+      - if: ${{ matrix.coreboot-tests }}
+        name: Run coreboot integration tests
         run: scripts/dev_cli.sh tests --integration-coreboot

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,29 +31,6 @@ pipeline {
                                                 }
                                         }
                                 }
-                                stage ('AArch64 Tests') {
-                                        agent { node { label 'focal-arm64' } }
-                                        stages {
-                                                stage ('Checkout') {
-                                                        steps {
-                                                                checkout scm
-                                                        }
-                                                }
-                                                stage('Run unit tests') {
-                                                          steps {
-                                                                  sh "scripts/dev_cli.sh tests --unit"
-                                                          }
-                                                }
-                                                stage('Run integration tests') {
-                                                          options {
-                                                                  timeout(time: 1, unit: 'HOURS')
-                                                          }
-                                                          steps {
-                                                                  sh "scripts/dev_cli.sh tests --integration"
-                                                          }
-                                                }
-                                        }
-                                }
                         }
                 }
         }


### PR DESCRIPTION
It looks like we have a self-hosted arm64/linux GitHub Actions runner (https://github.com/cloud-hypervisor/cloud-hypervisor/pull/6221).