### PR TITLE
ci: Import DCO check GHA from CH

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -1,0 +1,20 @@
+name: DCO
+on: [pull_request, merge_group]
+
+jobs:
+  check:
+    name: DCO Check ("Signed-Off-By")
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Check DCO
+      if: ${{ github.event_name == 'pull_request' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        pip3 install -U dco-check
+        dco-check -e "49699333+dependabot[bot]@users.noreply.github.com"


### PR DESCRIPTION
It looks like the DCO bot is not working. We should replace the bot with the GHA workflow imported from Cloud Hypervisor.