### PR TITLE
build: Update toolchain to nightly-2023-11-11

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -13,8 +13,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-permission:
-  packages: write
 
 jobs:
   main:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-11-10"
+channel = "nightly-2023-11-11"
 components = ["rust-src", "clippy", "rustfmt"]
 targets = [
     "aarch64-unknown-linux-gnu",


### PR DESCRIPTION
This update is to trigger container image build.
The [previous CI build](https://github.com/cloud-hypervisor/rust-hypervisor-firmware/actions/runs/8188441628/job/22478383773) is failing due to 403 error: https://github.com/cloud-hypervisor/rust-hypervisor-firmware/actions/runs/8188441628/job/22478383773#step:8:4457.