### PR TITLE
build: Use self hosted runners for x86-64 workload

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,20 +4,29 @@ on: [pull_request, create]
 jobs:
   build:
     name: Tests
-    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-22.04
+          - runner: x86-64
             coreboot-tests: true
-          - runner: focal-arm64
+          - runner: arm64
             coreboot-tests: false
+    runs-on: ${{ matrix.runner == 'x86-64' && 'garm-jammy-16' || 'focal-arm64' }}
     steps:
       - name: Code checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install Docker
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install ca-certificates curl gnupg
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+          sudo chmod a+r /usr/share/keyrings/docker-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          sudo apt install -y docker-ce docker-ce-cli
       - name: Run unit tests
         run: scripts/dev_cli.sh tests --unit
       - name: Run integration tests


### PR DESCRIPTION
Also tweak the naming of the jobs to make them more readable.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
