### PR TITLE
integration: Switch to use upstream Clear Linux image

### DIFF
--- a/scripts/fetch_images.sh
+++ b/scripts/fetch_images.sh
@@ -59,16 +59,22 @@ fetch_raw_ubuntu_image() {
     convert_image "$OS_IMAGE_NAME" "$OS_RAW_IMAGE_NAME"
 }
 
+fetch_clear_image() {
+    OS_VERSION="$1"
+    OS_IMAGE_NAME="clear-$OS_VERSION-cloudguest.img"
+    OS_IMAGE_BASE="https://cdn.download.clearlinux.org/releases/$OS_VERSION/clear"
+    OS_IMAGE_URL="$OS_IMAGE_BASE/$OS_IMAGE_NAME.xz"
+    fetch_image "$OS_IMAGE_NAME" "$OS_IMAGE_URL"
+    xz -d "$OS_IMAGE_NAME.xz"
+}
+
 aarch64_fetch_disk_images() {
     fetch_raw_ubuntu_image "focal" "arm64" "current"
     fetch_raw_ubuntu_image "jammy" "arm64" "current"
 }
 
 x86_64_fetch_disk_images() {
-    CLEAR_OS_IMAGE_NAME="clear-31311-cloudguest.img"
-    CLEAR_OS_URL_BASE="https://cloud-hypervisor.azureedge.net/"
-    CLEAR_OS_IMAGE_URL="$CLEAR_OS_URL_BASE/$CLEAR_OS_IMAGE_NAME"
-    fetch_image "$CLEAR_OS_IMAGE_NAME" "$CLEAR_OS_IMAGE_URL"
+    fetch_clear_image "31310"
 
     fetch_raw_ubuntu_image "focal" "amd64" "current"
     fetch_raw_ubuntu_image "jammy" "amd64" "current"

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -632,7 +632,7 @@ mod tests {
 
             const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-amd64-raw.img";
             const JAMMY_IMAGE_NAME: &str = "jammy-server-cloudimg-amd64-raw.img";
-            const CLEAR_IMAGE_NAME: &str = "clear-31311-cloudguest.img";
+            const CLEAR_IMAGE_NAME: &str = "clear-31310-cloudguest.img";
 
             #[test]
             fn test_boot_qemu_focal() {


### PR DESCRIPTION
Since the custom Clear Linux image is no longer available, this commit switches to use the upstream image for integration tests.