### PR TITLE
build: Remove heap allocator

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,11 +28,11 @@ jobs:
       - name: Install Rust components
         run: rustup component add rust-src clippy rustfmt
       - name: Build (debug)
-        run: cargo build --target ${{ matrix.target }} -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
+        run: cargo build --target ${{ matrix.target }} -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
       - name: Build (release)
-        run: cargo build --release --target ${{ matrix.target }} -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
+        run: cargo build --release --target ${{ matrix.target }} -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
       - name: Clippy (default)
-        run: cargo clippy --target ${{ matrix.target }} -Zbuild-std=core,alloc
+        run: cargo clippy --target ${{ matrix.target }} -Zbuild-std=core
       - name: Clippy (all targets, all features)
         run: cargo clippy --all-targets --all-features
       - name: Formatting

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,9 +19,9 @@ jobs:
       - name: Install rust-src
         run: rustup component add rust-src
       - name: Build (release) for x86_64
-        run: cargo build --release --target x86_64-unknown-none.json -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
+        run: cargo build --release --target x86_64-unknown-none.json -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
       - name: Build (release) for aarch64
-        run: cargo build --release --target aarch64-unknown-none.json -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
+        run: cargo build --release --target aarch64-unknown-none.json -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
       - name: Create release
         id: create_release
         uses: actions/create-release@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cc"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +123,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "hypervisor-fw"
 version = "0.4.2"
 dependencies = [
@@ -126,7 +151,7 @@ dependencies = [
  "chrono",
  "dirs",
  "fdt",
- "linked_list_allocator",
+ "heapless",
  "r-efi",
  "rand",
  "ssh2",
@@ -175,15 +200,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "linked_list_allocator"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e322f259d225fbae43a1b053b2dc6a5968a6bdf8b205f5de684dab485b95030e"
-dependencies = [
- "spinning_top",
 ]
 
 [[package]]
@@ -372,15 +388,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
-name = "spinning_top"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd0ab6b8c375d2d963503b90d3770010d95bc3b5f98036f948dee24bf4e8879"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "ssh2"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +398,12 @@ dependencies = [
  "libssh2-sys",
  "parking_lot",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ efi-var = []
 bitflags = "2.5.0"
 atomic_refcell = "0.1.13"
 r-efi = { version = "4.4.0", features = ["efiapi"] }
-linked_list_allocator = "0.10.4"
+heapless = "0.8.0"
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 tock-registers = "0.9.0"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ all the way into the OS.
 To compile:
 
 ```
-cargo build --release --target x86_64-unknown-none.json -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
+cargo build --release --target x86_64-unknown-none.json -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
 ```
 
 The result will be in:
@@ -101,7 +101,7 @@ $ qemu-system-x86_64 -machine q35,accel=kvm -cpu host,-vmx -m 1G\
 To compile:
 
 ```
-cargo build --release --target aarch64-unknown-none.json -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
+cargo build --release --target aarch64-unknown-none.json -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
 ```
 
 The result will be in:
@@ -121,7 +121,7 @@ will become available in the future.
 To compile:
 
 ```
-cargo build --release --target riscv64gcv-unknown-none-elf.json -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
+cargo build --release --target riscv64gcv-unknown-none-elf.json -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
 ```
 
 The result will be in:

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -274,7 +274,7 @@ cmd_build() {
 	   --env RUSTFLAGS="$rustflags" \
 	   "$CTR_IMAGE" \
 	   cargo build --target "$target" \
-	         -Zbuild-std=core,alloc \
+	         -Zbuild-std=core \
 	         -Zbuild-std-features=compiler-builtins-mem \
 	         --target-dir "$CTR_RHF_CARGO_TARGET" \
 	         "${cargo_args[@]}" && say "Binary placed under $RHF_CARGO_TARGET/target/$build"

--- a/scripts/run_cargo_tests.sh
+++ b/scripts/run_cargo_tests.sh
@@ -9,7 +9,7 @@ export RUSTFLAGS="-D warnings"
 arch="$(uname -m)"
 
 do_cargo_tests() {
-    local cargo_args=("-Zbuild-std=core,alloc" "-Zbuild-std-features=compiler-builtins-mem")
+    local cargo_args=("-Zbuild-std=core" "-Zbuild-std-features=compiler-builtins-mem")
     local cmd="$1"
     local target="$2"
     local features="$3"

--- a/scripts/run_coreboot_integration_tests.sh
+++ b/scripts/run_coreboot_integration_tests.sh
@@ -16,7 +16,7 @@ fetch_disk_images "$WORKLOADS_DIR" "$arch"
 [ "$arch" = "x86_64" ] && target="x86_64-unknown-none"
 
 rustup component add rust-src
-cargo build --release --target "$target.json" -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem --features "coreboot"
+cargo build --release --target "$target.json" -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem --features "coreboot"
 
 RHF_BIN="$RHF_ROOT_DIR/target/$target/release/hypervisor-fw"
 COREBOOT_CONFIG_IN="$RHF_ROOT_DIR/resources/coreboot/qemu-q35-config.in"

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -18,7 +18,7 @@ fetch_disk_images "$WORKLOADS_DIR" "$arch"
 [ "$arch" = "x86_64" ] && target="x86_64-unknown-none"
 
 rustup component add rust-src
-cargo build --release --target "$target.json" -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
+cargo build --release --target "$target.json" -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
 
 export RUST_BACKTRACE=1
 time cargo test --features "integration_tests" "integration::tests::linux::$arch" -- --test-threads=1

--- a/scripts/run_integration_tests_windows.sh
+++ b/scripts/run_integration_tests_windows.sh
@@ -31,7 +31,7 @@ dmsetup mknodes
 [ "$arch" = "x86_64" ] && target="x86_64-unknown-none"
 
 rustup component add rust-src
-cargo build --release --target "$target.json" -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
+cargo build --release --target "$target.json" -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem
 
 export RUST_BACKTRACE=1
 time cargo test --features "integration_tests" "integration::tests::windows::$arch"


### PR DESCRIPTION
PR #92 introduced heap allocator to implement EFI variable feature. However, none of other components uses heap. This commit removes the heap allocator and use the `heapless` crate instead of `Vec`. This change simplifies the build arguments.