### PR TITLE
log: Introduce log crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,7 @@ dependencies = [
  "dirs",
  "fdt",
  "heapless",
+ "log",
  "r-efi",
  "rand",
  "ssh2",
@@ -216,6 +217,12 @@ checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "num-traits"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ bitflags = "2.6.0"
 atomic_refcell = "0.1.13"
 r-efi = { version = "4.5.0", features = ["efiapi"] }
 heapless = "0.8.0"
+log = "0.4.22"
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 tock-registers = "0.9.0"

--- a/src/arch/x86_64/paging.rs
+++ b/src/arch/x86_64/paging.rs
@@ -2,6 +2,7 @@
 // Copyright 2020 Google LLC
 
 use core::cell::SyncUnsafeCell;
+use log::info;
 use x86_64::{
     registers::control::Cr3,
     structures::paging::{PageSize, PageTable, PageTableFlags, PhysFrame, Size2MiB},
@@ -25,7 +26,7 @@ pub fn setup() {
     // SAFETY: This function is idempontent and only writes to static memory and
     // CR3. Thus, it is safe to run multiple times or on multiple threads.
     let (l4, l3, l2s) = unsafe { (L4_TABLE.get_mut(), L3_TABLE.get_mut(), L2_TABLES.get_mut()) };
-    log!("Setting up {} GiB identity mapping", ADDRESS_SPACE_GIB);
+    info!("Setting up {} GiB identity mapping", ADDRESS_SPACE_GIB);
     let pt_flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
 
     // Setup Identity map using L2 huge pages
@@ -51,7 +52,7 @@ pub fn setup() {
     if cr3_frame != l4_frame {
         unsafe { Cr3::write(l4_frame, cr3_flags) };
     }
-    log!("Page tables setup");
+    info!("Page tables setup");
 }
 
 // Map a virtual address to a PhysAddr (assumes identity mapping)

--- a/src/efi/device_path.rs
+++ b/src/efi/device_path.rs
@@ -7,6 +7,7 @@ use core::{
     ptr::null_mut,
 };
 
+use log::error;
 use r_efi::{
     efi::{self, MemoryType, Status},
     protocols::device_path::Protocol as DevicePathProtocol,
@@ -49,7 +50,7 @@ impl DevicePath {
             }
 
             if dpp.r#type == r_efi::protocols::device_path::TYPE_END && dpp.sub_type == 0xff {
-                log!("Unexpected end of device path");
+                error!("Unexpected end of device path");
                 return DevicePath::Unsupported;
             }
             let len = unsafe { core::mem::transmute::<[u8; 2], u16>(dpp.length) };

--- a/src/efi/file.rs
+++ b/src/efi/file.rs
@@ -3,6 +3,7 @@
 
 use core::ffi::c_void;
 
+use log::error;
 use r_efi::{
     efi::{self, Char16, Guid, Status},
     protocols::{
@@ -51,7 +52,7 @@ pub extern "efiapi" fn open(
         match &wrapper.node {
             crate::fat::Node::Directory(d) => d,
             _ => {
-                log!("Attempt to open from non-directory is unsupported");
+                error!("Attempt to open from non-directory is unsupported");
                 return Status::UNSUPPORTED;
             }
         }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 Akira Moroo
+
+pub struct Logger;
+
+impl log::Log for Logger {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        metadata.level() <= log::Level::Info
+    }
+
+    fn log(&self, record: &log::Record) {
+        if self.enabled(record.metadata()) {
+            log!("[{}] {}", record.level(), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+pub fn init() {
+    log::set_logger(&Logger).expect("Failed to set logger");
+    log::set_max_level(log::LevelFilter::Info);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,7 @@ mod fdt;
 mod integration;
 mod layout;
 mod loader;
+mod logger;
 mod mem;
 mod part;
 mod pci;
@@ -183,6 +184,7 @@ fn boot_from_device(
 #[no_mangle]
 pub extern "C" fn rust64_start(#[cfg(not(feature = "coreboot"))] pvh_info: &pvh::StartInfo) -> ! {
     serial::PORT.borrow_mut().init();
+    logger::init();
 
     arch::x86_64::sse::enable_sse();
     arch::x86_64::paging::setup();
@@ -204,6 +206,7 @@ pub extern "C" fn rust64_start(x0: *const u8) -> ! {
 
     // Use atomic operation before MMU enabled may cause exception, see https://www.ipshop.xyz/5909.html
     serial::PORT.borrow_mut().init();
+    logger::init();
 
     let info = fdt::StartInfo::new(
         x0,
@@ -226,6 +229,7 @@ pub extern "C" fn rust64_start(a0: u64, a1: *const u8) -> ! {
     use crate::bootinfo::{EntryType, Info, MemoryEntry};
 
     serial::PORT.borrow_mut().init();
+    logger::init();
 
     log!("Starting on RV64 0x{:x} 0x{:x}", a0, a1 as u64,);
 

--- a/src/pci.rs
+++ b/src/pci.rs
@@ -3,6 +3,7 @@
 
 use atomic_refcell::AtomicRefCell;
 
+use log::{info, warn};
 #[cfg(target_arch = "x86_64")]
 use x86_64::instructions::port::{Port, PortWriteOnly};
 
@@ -152,11 +153,9 @@ pub fn print_bus() {
         if vendor_id == INVALID_VENDOR_ID {
             continue;
         }
-        log!(
+        info!(
             "Found PCI device vendor={:x} device={:x} in slot={}",
-            vendor_id,
-            device_id,
-            device
+            vendor_id, device_id, device
         );
     }
 }
@@ -251,13 +250,9 @@ impl PciDevice {
         self.vendor_id = vendor_id;
         self.device_id = device_id;
 
-        log!(
+        info!(
             "PCI Device: {}:{}.{} {:x}:{:x}",
-            self.bus,
-            self.device,
-            self.func,
-            self.vendor_id,
-            self.device_id
+            self.bus, self.device, self.func, self.vendor_id, self.device_id
         );
 
         // Enable responses in memory space
@@ -328,11 +323,9 @@ impl PciDevice {
 
         #[allow(clippy::disallowed_names)]
         for bar in &self.bars {
-            log!(
+            info!(
                 "Bar: type={:?} address=0x{:x} size=0x{:x}",
-                bar.bar_type,
-                bar.address,
-                bar.size
+                bar.bar_type, bar.address, bar.size
             );
         }
     }
@@ -379,11 +372,9 @@ impl PciDevice {
 
         #[allow(clippy::disallowed_names)]
         for bar in &self.bars {
-            log!(
+            info!(
                 "Updated BARs: type={:?} address={:x} size={:x}",
-                bar.bar_type,
-                bar.address,
-                bar.size
+                bar.bar_type, bar.address, bar.size
             );
         }
 
@@ -445,7 +436,7 @@ impl VirtioTransport for VirtioPciTransport {
 
         // bit 4 of status is capability bit
         if status & 1 << 4 == 0 {
-            log!("No capabilities detected");
+            warn!("No capabilities detected");
             return Err(VirtioError::UnsupportedDevice);
         }
 


### PR DESCRIPTION
RHF has a simple `log!()` macro with a serial backend for logging, but it lacks a logging level feature for better tracing. This PR proposes to add the `log` crate and introduce logging level. This will change the output format with a logging level prefix like `[INFO]`.