### PR TITLE
github: Disable ARM64 tests as runner is unavailable

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,8 +11,6 @@ jobs:
         include:
           - runner: ubuntu-22.04
             coreboot-tests: true
-          - runner: focal-arm64
-            coreboot-tests: false
     steps:
       - name: Code checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
