### PR TITLE
github: Re-enable ARM64 tests using new runner

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,6 +11,8 @@ jobs:
         include:
           - runner: ubuntu-22.04
             coreboot-tests: true
+          - runner: bookworm-arm64
+            coreboot-tests: false
     steps:
       - name: Code checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This commit partially reverts c68544c3face22d4f2f40761a2b85835fa9f8f0d
with modifications for worker changes.
