### PR TITLE
aarch64/layout: Increase aarch64 system memory layout to 2TB.

### DIFF
--- a/src/arch/aarch64/layout.rs
+++ b/src/arch/aarch64/layout.rs
@@ -21,8 +21,8 @@ extern "Rust" {
 }
 
 pub mod map {
-    // Create page table for 128G is enough
-    pub const END: usize = 0x20_0000_0000;
+    // Create page table for 2T
+    pub const END: usize = 0x20_000_000_000;
 
     // Firmware region won't be used by this firmware, so merge it into mmio region
     // is harmless and better for management.


### PR DESCRIPTION
Bumping the possible page table range for aarch64 from 128G to 2TB to support larger systems. Without this increase we can't virtualize system memory beyond 128G for ARM CPUs.

Fixes #298