### PR TITLE
efi: Implement reset_system for Cloud Hypervisor

### DIFF
--- a/src/efi/runtime_services.rs
+++ b/src/efi/runtime_services.rs
@@ -196,8 +196,30 @@ pub extern "efiapi" fn get_next_high_mono_count(_: *mut u32) -> Status {
     Status::DEVICE_ERROR
 }
 
-pub extern "efiapi" fn reset_system(_: ResetType, _: Status, _: usize, _: *mut c_void) {
-    // Don't do anything to force the kernel to use ACPI for shutdown and triple-fault for reset
+pub extern "efiapi" fn reset_system(_reset_type: ResetType, _: Status, _: usize, _: *mut c_void) {
+    #[cfg(target_arch = "x86_64")]
+    {
+        // Cloud Hypervisor's AcpiShutdownDevice is at IO port 0x600.
+        const SHUTDOWN_PORT: u16 = 0x600;
+        const S5_SLEEP_VALUE: u8 = (5 << 2) | (1 << 5); // SLP_TYP=5, SLP_EN=1
+        const REBOOT_VALUE: u8 = 1;
+
+        let value = if _reset_type == efi::RESET_SHUTDOWN {
+            S5_SLEEP_VALUE
+        } else {
+            REBOOT_VALUE
+        };
+        unsafe {
+            core::arch::asm!("out dx, al", in("dx") SHUTDOWN_PORT, in("al") value);
+        }
+    }
+
+    loop {
+        #[cfg(target_arch = "x86_64")]
+        unsafe {
+            core::arch::asm!("hlt");
+        }
+    }
 }
 
 pub extern "efiapi" fn update_capsule(


### PR DESCRIPTION
## Summary

Implement the EFI `ResetSystem` runtime service to write to Cloud Hypervisor's `AcpiShutdownDevice` I/O port (0x600).

The function was intentionally left as a no-op to force Linux to use ACPI for shutdown. Linux does fall back correctly, but Windows calls `ResetSystem(EfiResetShutdown)` as its final shutdown step and does not fall back to ACPI. This causes the Cloud Hypervisor process to hang indefinitely after a Windows guest shuts down.

## Changes

- `EfiResetShutdown`: write `0x34` (SLP_TYP=5, SLP_EN=1) to port
  0x600, triggering a clean VM exit
- `EfiResetCold`/`EfiResetWarm`: write `0x01` to port 0x600,
  triggering a VM reset

## Test results

| Scenario | Before | After |
|----------|--------|-------|
| SSH `shutdown /s /t 0` | CH hangs forever | **22s exit** |
| ACPI power button | CH hangs forever | **19s exit** |

Linux guests are unaffected as they use ACPI directly for shutdown.

Fixes: #422

Signed-off-by: CMGS <ilskdw@gmail.com>