### PR TITLE
efi: Implement reset_system for Cloud Hypervisor

### DIFF
--- a/src/efi/boot_services.rs
+++ b/src/efi/boot_services.rs
@@ -453,6 +453,9 @@ pub extern "efiapi" fn unload_image(_: Handle) -> Status {
 }
 
 pub extern "efiapi" fn exit_boot_services(_: Handle, _: usize) -> Status {
+    unsafe {
+        super::runtime_services::swap_reset_system();
+    }
     Status::SUCCESS
 }
 

--- a/src/efi/runtime_services.rs
+++ b/src/efi/runtime_services.rs
@@ -38,7 +38,7 @@ pub static mut RS: SyncUnsafeCell<efi::RuntimeServices> =
         get_next_variable_name,
         set_variable,
         get_next_high_mono_count,
-        reset_system,
+        reset_system: reset_system_boot,
         update_capsule,
         query_capsule_capabilities,
         query_variable_info,
@@ -62,7 +62,11 @@ unsafe fn fixup_at_virtual(descriptors: &[MemoryDescriptor]) {
     rs.get_variable = transmute(ptr);
     rs.set_variable = transmute(ptr);
     rs.get_next_variable_name = transmute(ptr);
-    rs.reset_system = transmute(ptr);
+    let reset_ptr = ALLOCATOR
+        .borrow()
+        .convert_internal_pointer(descriptors, (reset_system as *const ()) as u64)
+        .unwrap();
+    rs.reset_system = transmute(reset_ptr);
     rs.update_capsule = transmute(ptr);
     rs.query_capsule_capabilities = transmute(ptr);
     rs.query_variable_info = transmute(ptr);
@@ -196,10 +200,24 @@ pub extern "efiapi" fn get_next_high_mono_count(_: *mut u32) -> Status {
     Status::DEVICE_ERROR
 }
 
+// No-op used during boot services phase. EFI applications like shim may call
+// ResetSystem during early boot (e.g. on MOK import failure). Returning here
+// lets them continue, matching the original firmware behavior.
+pub extern "efiapi" fn reset_system_boot(
+    _: ResetType,
+    _: Status,
+    _: usize,
+    _: *mut c_void,
+) {
+}
+
+// Activated after ExitBootServices via swap_reset_system(). Writes to Cloud
+// Hypervisor's AcpiShutdownDevice at IO port 0x600 to perform the actual
+// VM shutdown or reset. On non-CH platforms the port write is a no-op and
+// the function falls through to a halt loop.
 pub extern "efiapi" fn reset_system(_reset_type: ResetType, _: Status, _: usize, _: *mut c_void) {
     #[cfg(target_arch = "x86_64")]
     {
-        // Cloud Hypervisor's AcpiShutdownDevice is at IO port 0x600.
         const SHUTDOWN_PORT: u16 = 0x600;
         const S5_SLEEP_VALUE: u8 = (5 << 2) | (1 << 5); // SLP_TYP=5, SLP_EN=1
         const REBOOT_VALUE: u8 = 1;
@@ -222,6 +240,14 @@ pub extern "efiapi" fn reset_system(_reset_type: ResetType, _: Status, _: usize,
         #[cfg(not(target_arch = "x86_64"))]
         core::hint::spin_loop();
     }
+}
+
+/// Switch the runtime services table from the boot-phase no-op to the real
+/// reset_system implementation. Called from exit_boot_services.
+pub unsafe fn swap_reset_system() {
+    #[allow(static_mut_refs)]
+    let rs = RS.get_mut();
+    rs.reset_system = reset_system;
 }
 
 pub extern "efiapi" fn update_capsule(

--- a/src/efi/runtime_services.rs
+++ b/src/efi/runtime_services.rs
@@ -196,8 +196,32 @@ pub extern "efiapi" fn get_next_high_mono_count(_: *mut u32) -> Status {
     Status::DEVICE_ERROR
 }
 
-pub extern "efiapi" fn reset_system(_: ResetType, _: Status, _: usize, _: *mut c_void) {
-    // Don't do anything to force the kernel to use ACPI for shutdown and triple-fault for reset
+pub extern "efiapi" fn reset_system(_reset_type: ResetType, _: Status, _: usize, _: *mut c_void) {
+    #[cfg(target_arch = "x86_64")]
+    {
+        // Cloud Hypervisor's AcpiShutdownDevice is at IO port 0x600.
+        const SHUTDOWN_PORT: u16 = 0x600;
+        const S5_SLEEP_VALUE: u8 = (5 << 2) | (1 << 5); // SLP_TYP=5, SLP_EN=1
+        const REBOOT_VALUE: u8 = 1;
+
+        let value = if _reset_type == efi::RESET_SHUTDOWN {
+            S5_SLEEP_VALUE
+        } else {
+            REBOOT_VALUE
+        };
+        unsafe {
+            core::arch::asm!("out dx, al", in("dx") SHUTDOWN_PORT, in("al") value);
+        }
+    }
+
+    loop {
+        #[cfg(target_arch = "x86_64")]
+        unsafe {
+            core::arch::asm!("hlt");
+        }
+        #[cfg(not(target_arch = "x86_64"))]
+        core::hint::spin_loop();
+    }
 }
 
 pub extern "efiapi" fn update_capsule(

--- a/src/efi/runtime_services.rs
+++ b/src/efi/runtime_services.rs
@@ -203,13 +203,7 @@ pub extern "efiapi" fn get_next_high_mono_count(_: *mut u32) -> Status {
 // No-op used during boot services phase. EFI applications like shim may call
 // ResetSystem during early boot (e.g. on MOK import failure). Returning here
 // lets them continue, matching the original firmware behavior.
-pub extern "efiapi" fn reset_system_boot(
-    _: ResetType,
-    _: Status,
-    _: usize,
-    _: *mut c_void,
-) {
-}
+pub extern "efiapi" fn reset_system_boot(_: ResetType, _: Status, _: usize, _: *mut c_void) {}
 
 // Activated after ExitBootServices via swap_reset_system(). Writes to Cloud
 // Hypervisor's AcpiShutdownDevice at IO port 0x600 to perform the actual

--- a/src/efi/runtime_services.rs
+++ b/src/efi/runtime_services.rs
@@ -38,7 +38,7 @@ pub static mut RS: SyncUnsafeCell<efi::RuntimeServices> =
         get_next_variable_name,
         set_variable,
         get_next_high_mono_count,
-        reset_system,
+        reset_system: reset_system_boot,
         update_capsule,
         query_capsule_capabilities,
         query_variable_info,
@@ -62,7 +62,11 @@ unsafe fn fixup_at_virtual(descriptors: &[MemoryDescriptor]) {
     rs.get_variable = transmute(ptr);
     rs.set_variable = transmute(ptr);
     rs.get_next_variable_name = transmute(ptr);
-    rs.reset_system = transmute(ptr);
+    let reset_ptr = ALLOCATOR
+        .borrow()
+        .convert_internal_pointer(descriptors, (reset_system as *const ()) as u64)
+        .unwrap();
+    rs.reset_system = transmute(reset_ptr);
     rs.update_capsule = transmute(ptr);
     rs.query_capsule_capabilities = transmute(ptr);
     rs.query_variable_info = transmute(ptr);
@@ -196,8 +200,48 @@ pub extern "efiapi" fn get_next_high_mono_count(_: *mut u32) -> Status {
     Status::DEVICE_ERROR
 }
 
-pub extern "efiapi" fn reset_system(_: ResetType, _: Status, _: usize, _: *mut c_void) {
-    // Don't do anything to force the kernel to use ACPI for shutdown and triple-fault for reset
+// No-op used during boot services phase. EFI applications like shim may call
+// ResetSystem during early boot (e.g. on MOK import failure). Returning here
+// lets them continue, matching the original firmware behavior.
+pub extern "efiapi" fn reset_system_boot(_: ResetType, _: Status, _: usize, _: *mut c_void) {}
+
+// Activated after ExitBootServices via swap_reset_system(). Writes to Cloud
+// Hypervisor's AcpiShutdownDevice at IO port 0x600 to perform the actual
+// VM shutdown or reset. On non-CH platforms the port write is a no-op and
+// the function falls through to a halt loop.
+pub extern "efiapi" fn reset_system(_reset_type: ResetType, _: Status, _: usize, _: *mut c_void) {
+    #[cfg(target_arch = "x86_64")]
+    {
+        const SHUTDOWN_PORT: u16 = 0x600;
+        const S5_SLEEP_VALUE: u8 = (5 << 2) | (1 << 5); // SLP_TYP=5, SLP_EN=1
+        const REBOOT_VALUE: u8 = 1;
+
+        let value = if _reset_type == efi::RESET_SHUTDOWN {
+            S5_SLEEP_VALUE
+        } else {
+            REBOOT_VALUE
+        };
+        unsafe {
+            core::arch::asm!("out dx, al", in("dx") SHUTDOWN_PORT, in("al") value);
+        }
+    }
+
+    loop {
+        #[cfg(target_arch = "x86_64")]
+        unsafe {
+            core::arch::asm!("hlt");
+        }
+        #[cfg(not(target_arch = "x86_64"))]
+        core::hint::spin_loop();
+    }
+}
+
+/// Switch the runtime services table from the boot-phase no-op to the real
+/// reset_system implementation. Called from exit_boot_services.
+pub unsafe fn swap_reset_system() {
+    #[allow(static_mut_refs)]
+    let rs = RS.get_mut();
+    rs.reset_system = reset_system;
 }
 
 pub extern "efiapi" fn update_capsule(


### PR DESCRIPTION
Implement the EFI `ResetSystem` runtime service to write to Cloud Hypervisor's `AcpiShutdownDevice` I/O port (0x600).

The function was intentionally left as a no-op to force Linux to use ACPI for shutdown. Linux does fall back correctly, but Windows calls `ResetSystem(EfiResetShutdown)` as its final shutdown step and does not fall back to ACPI. This causes the Cloud Hypervisor process to hang indefinitely after Windows shuts down.

On x86_64, write the appropriate value based on reset type:
- `EfiResetShutdown`: SLP_TYP=5 + SLP_EN → triggers VM exit
- `EfiResetCold`/`EfiResetWarm`: reboot value → triggers VM reset

On other architectures (aarch64, riscv64), the function remains a no-op — these platforms use PSCI for shutdown/reboot.

| Scenario | Before | After |
|----------|--------|-------|
| SSH `shutdown /s /t 0` | CH hangs forever | 22s exit |
| ACPI power button | CH hangs forever | 19s exit |

Linux guests are unaffected.

Fixes: #422

Signed-off-by: CMGS <ilskdw@gmail.com>