### PR TITLE
Update CI configuration for Dependabot and Ubuntu runner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,5 @@ updates:
 - package-ecosystem: cargo
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 3
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   main:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Code checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ jobs:
   release:
     if: github.event_name == 'create' && github.event.ref_type == 'tag'
     name: Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Code checkout
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-22.04
+          - runner: ubuntu-24.04
             coreboot-tests: true
           - runner: bookworm-arm64
             coreboot-tests: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,9 @@ jobs:
           - runner: bookworm-arm64
             coreboot-tests: false
     steps:
+      - name: Remove stale build artifacts
+        run: |
+          sudo rm -rf build || true
       - name: Code checkout
         uses: actions/checkout@v4
         with:

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -268,6 +268,7 @@ cmd_build() {
 
     $DOCKER_RUNTIME run \
 	   --workdir "$CTR_RHF_ROOT_DIR" \
+	   --user "$(id -u):$(id -g)" \
 	   --rm \
 	   --volume $exported_device \
 	   --volume "$RHF_ROOT_DIR:$CTR_RHF_ROOT_DIR" $exported_volumes \


### PR DESCRIPTION
This PR improves CI configs:

- Update Dependabot config
- Switch to Ubuntu 24.04 CI runner
- Remove slate build artifacts before source checkout