### PR TITLE
x86_64: lock IA32_FEATURE_CONTROL with VMXON enabled at boot

### DIFF
--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -7,3 +7,4 @@ pub mod gdt;
 pub mod layout;
 pub mod paging;
 pub mod sse;
+pub mod vmx;

--- a/src/arch/x86_64/vmx.rs
+++ b/src/arch/x86_64/vmx.rs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use core::arch::x86_64::__cpuid;
+use x86_64::registers::model_specific::Msr;
+
+const IA32_FEATURE_CONTROL: u32 = 0x3a;
+const FEATURE_CONTROL_LOCKED: u64 = 1 << 0;
+const FEATURE_CONTROL_VMXON_OUTSIDE_SMX: u64 = 1 << 2;
+const CPUID_1_ECX_VMX: u32 = 1 << 5;
+
+// A guest hypervisor (Hyper-V / WSL2) refuses VMXON unless firmware locked
+// IA32_FEATURE_CONTROL with VMXON enabled; real BIOS does this at boot, so we
+// must too or nested virt is unusable despite VMX in CPUID.
+pub fn enable_feature_control() {
+    let has_vmx = unsafe { __cpuid(1) }.ecx & CPUID_1_ECX_VMX != 0;
+    if !has_vmx {
+        return;
+    }
+    let mut msr = Msr::new(IA32_FEATURE_CONTROL);
+    let current = unsafe { msr.read() };
+    if current & FEATURE_CONTROL_LOCKED == 0 {
+        unsafe { msr.write(current | FEATURE_CONTROL_VMXON_OUTSIDE_SMX | FEATURE_CONTROL_LOCKED) };
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,6 +185,7 @@ pub extern "C" fn rust64_start(#[cfg(not(feature = "coreboot"))] pvh_info: &pvh:
 
     arch::x86_64::sse::enable_sse();
     arch::x86_64::paging::setup();
+    arch::x86_64::vmx::enable_feature_control();
 
     #[cfg(feature = "coreboot")]
     let info = &coreboot::StartInfo::default();


### PR DESCRIPTION
Guest hypervisors (Windows Hyper-V, WSL2) check `IA32_FEATURE_CONTROL` (MSR
`0x3A`) at boot and refuse `VMXON` unless the firmware has set the lock bit
with VMXON-outside-SMX enabled — otherwise they report "virtualization not
enabled in firmware". rust-hypervisor-firmware never touched this MSR, so a
Windows guest saw VMX in CPUID (`VMMonitorModeExtensions=True`) but
`VirtualizationFirmwareEnabled=False`, and Hyper-V launch failed with Event 41
"Either VMX not present or not enabled in BIOS". Nested virtualization was
therefore unusable.

Set the MSR the way real firmware does: in `rust64_start`, when `CPUID.1:ECX.VMX`
reports VMX support, lock `IA32_FEATURE_CONTROL` with bit 0 (LOCKED) and bit 2
(VMXON-outside-SMX), before handing control to the OS. The write is skipped when
the lock bit is already set (idempotent) and when VMX is absent (AMD / nested
off), so AMD and non-nested guests are unaffected. Other architectures
(aarch64, riscv64) are not touched.

Verified on a Cloud Hypervisor Windows 11 guest: `VirtualizationFirmwareEnabled`
flips False to True and the guest boots normally.

Signed-off-by: tonic <tonicbupt@gmail.com>
